### PR TITLE
Feature/add initial db

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -13,7 +13,7 @@ gem "puma", ">= 5.0"
 # gem "bcrypt", "~> 3.1.7"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem "tzinfo-data", platforms: %i[ windows jruby ]
+gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]
 
 # Use the database-backed adapters for Rails.cache, Active Job, and Action Cable
 gem "solid_cache"

--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -37,7 +37,7 @@ gem "image_processing", "~> 1.2"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
-  gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"
+  gem "debug", platforms: %i[ mri mingw mswin x64_mingw ], require: "debug/prelude"
 
   # Audits gems for known security defects (use config/bundler-audit.yml to ignore issues)
   gem "bundler-audit", require: false

--- a/backend/app/models/category.rb
+++ b/backend/app/models/category.rb
@@ -1,0 +1,5 @@
+class Category < ApplicationRecord
+  has_many :spots, dependent: :restrict_with_exception
+
+  validates :name, presence: true, uniqueness: true
+end

--- a/backend/app/models/spot.rb
+++ b/backend/app/models/spot.rb
@@ -1,0 +1,11 @@
+class Spot < ApplicationRecord
+  enum :status, {
+    want_to_go: "want_to_go",
+    visited: "visited"
+  }, validate: true
+
+  belongs_to :category
+
+  validates :name, presence: true
+  validates :status, presence: true
+end

--- a/backend/db/migrate/20260408030614_create_categories.rb
+++ b/backend/db/migrate/20260408030614_create_categories.rb
@@ -1,0 +1,11 @@
+class CreateCategories < ActiveRecord::Migration[8.1]
+  def change
+    create_table :categories do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+
+    add_index :categories, :name, unique: true
+  end
+end

--- a/backend/db/migrate/20260408030757_create_spots.rb
+++ b/backend/db/migrate/20260408030757_create_spots.rb
@@ -1,0 +1,17 @@
+class CreateSpots < ActiveRecord::Migration[8.1]
+  def change
+    create_table :spots do |t|
+      t.references :category, null: false, foreign_key: true
+      t.string :name, null: false
+      t.text :note
+      t.string :url
+      t.string :status, null: false, default: "want_to_go"
+      t.date :visited_on
+
+      t.timestamps
+    end
+
+    add_index :spots, :status
+    add_check_constraint :spots, "status IN ('want_to_go', 'visited')", name: "spots_status_check"
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,8 +10,30 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 0) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_08_030757) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
+  create_table "categories", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_categories_on_name", unique: true
+  end
+
+  create_table "spots", force: :cascade do |t|
+    t.bigint "category_id", null: false
+    t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.text "note"
+    t.string "status", default: "want_to_go", null: false
+    t.datetime "updated_at", null: false
+    t.string "url"
+    t.date "visited_on"
+    t.index ["category_id"], name: "index_spots_on_category_id"
+    t.index ["status"], name: "index_spots_on_status"
+    t.check_constraint "status::text = ANY (ARRAY['want_to_go'::character varying, 'visited'::character varying]::text[])", name: "spots_status_check"
+  end
+
+  add_foreign_key "spots", "categories"
 end

--- a/backend/test/fixtures/categories.yml
+++ b/backend/test/fixtures/categories.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: Cafe
+
+two:
+  name: Bookstore

--- a/backend/test/fixtures/spots.yml
+++ b/backend/test/fixtures/spots.yml
@@ -1,0 +1,17 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  category: one
+  name: Morning Cafe
+  note: Quiet place for breakfast
+  url: https://example.com/cafe
+  status: want_to_go
+  visited_on: 2026-04-08
+
+two:
+  category: two
+  name: Weekend Bookstore
+  note: Nice indie bookstore
+  url: https://example.com/bookstore
+  status: visited
+  visited_on: 2026-04-08

--- a/backend/test/models/category_test.rb
+++ b/backend/test/models/category_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class CategoryTest < ActiveSupport::TestCase
+  test "is valid with a name" do
+    category = Category.new(name: "Ramen")
+
+    assert category.valid?
+  end
+
+  test "is invalid without a name" do
+    category = Category.new(name: nil)
+
+    assert_not category.valid?
+    assert_includes category.errors[:name], "can't be blank"
+  end
+
+  test "is invalid with a duplicate name" do
+    category = Category.new(name: categories(:one).name)
+
+    assert_not category.valid?
+    assert_includes category.errors[:name], "has already been taken"
+  end
+end

--- a/backend/test/models/spot_test.rb
+++ b/backend/test/models/spot_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+
+class SpotTest < ActiveSupport::TestCase
+  test "is valid with required attributes" do
+    spot = Spot.new(name: "Local Cafe", category: categories(:one), status: :want_to_go)
+
+    assert spot.valid?
+  end
+
+  test "is invalid without a name" do
+    spot = Spot.new(name: nil, category: categories(:one), status: :want_to_go)
+
+    assert_not spot.valid?
+    assert_includes spot.errors[:name], "can't be blank"
+  end
+
+  test "is invalid without a category" do
+    spot = Spot.new(name: "Local Cafe", category: nil, status: :want_to_go)
+
+    assert_not spot.valid?
+    assert_includes spot.errors[:category], "must exist"
+  end
+
+  test "is invalid with an unsupported status" do
+    spot = Spot.new(name: "Local Cafe", category: categories(:one), status: "archived")
+
+    assert_not spot.valid?
+    assert_includes spot.errors[:status], "is not included in the list"
+  end
+
+  test "allows duplicate names across spots" do
+    spot = Spot.new(name: spots(:one).name, category: categories(:two), status: :visited)
+
+    assert spot.valid?
+  end
+end


### PR DESCRIPTION
## 概要
  `Category` / `Spot` の初期DB定義を追加し、あわせてモデル
  のバリデーションを確認するテストを追加しました。

  ## 変更内容
  ### DB・モデル
  - `categories` テーブルを追加
  - `spots` テーブルを追加
  - `Category` / `Spot` モデルを追加
  - 必須項目の制約を追加
  - `categories.name` に一意制約を追加
  - `spots.status` に default / index / check constraint
  を追加
  - `Spot` の `status` を enum として定義

  ### テスト
  - `Category` モデルのテストを追加
    - name の必須チェック
    - name の一意性チェック
  - `Spot` モデルのテストを追加
    - name の必須チェック
    - category の必須チェック
    - status の妥当性チェック
  - fixture を追加

  ## 目的
  Spot を保存・管理するための基礎となるデータ構造を整え、
  モデルの基本的な整合性をテストで担保するためです。

  ## 影響範囲
  - バックエンドのDB定義
  - モデル
  - モデルテスト
  - APIや画面の挙動変更はまだありません

  ## 補足
  コミットは以下の2つに分けています。
  - `feat: add categories and spots schema constraints`
  - `test: add model tests for categories and spots`

closes #10 