### PR TITLE
feature: add create spot api

### DIFF
--- a/backend/app/controllers/api/categories_controller.rb
+++ b/backend/app/controllers/api/categories_controller.rb
@@ -1,0 +1,20 @@
+module Api
+  class CategoriesController < ApplicationController
+
+    def create
+      category = Category.new(category_params)
+
+      if category.save
+        render json: category, status: :created
+      else
+        render json: { errors: category.errors.full_messages }, status: :unprocessable_entity
+      end
+    end
+
+    private
+
+    def category_params
+      params.require(:category).permit(:name)
+    end
+  end
+end

--- a/backend/app/controllers/api/spots_controller.rb
+++ b/backend/app/controllers/api/spots_controller.rb
@@ -1,0 +1,20 @@
+module Api
+  class SpotsController < ApplicationController
+
+    def create
+      spot = Spot.new(spot_params)
+
+      if spot.save
+        render json: spot, status: :created
+      else
+        render json: { errors: spot.errors.full_messages }, status: :unprocessable_entity
+      end
+    end
+
+    private
+
+    def spot_params
+      params.require(:spot).permit(:category_id, :name, :note, :url, :status, :visited_on)
+    end
+  end
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,10 +1,9 @@
 Rails.application.routes.draw do
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
-  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
-  # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check
 
-  # Defines the root path route ("/")
-  # root "posts#index"
+  namespace :api do
+    resources :categories, only: [:create]
+    resources :spots, only: [:create]
+  end
 end

--- a/backend/test/controllers/api/categories_controller_test.rb
+++ b/backend/test/controllers/api/categories_controller_test.rb
@@ -1,0 +1,45 @@
+require "test_helper"
+
+class Api::CategoriesControllerTest < ActionDispatch::IntegrationTest
+  test "creates a category" do
+    assert_difference("Category.count", 1) do
+      post "/api/categories",
+        params: { category: { name: "Ramen" } },
+        as: :json
+    end
+
+    assert_response :created
+
+    response_json = JSON.parse(response.body)
+
+    assert_equal "Ramen", response_json["name"]
+  end
+
+  test "returns errors when category is invalid" do
+    assert_no_difference("Category.count") do
+      post "/api/categories",
+        params: { category: { name: "" } },
+        as: :json
+    end
+
+    assert_response :unprocessable_entity
+
+    response_json = JSON.parse(response.body)
+
+    assert_includes response_json["errors"], "Name can't be blank"
+  end
+
+  test "returns errors when category name is duplicated" do
+    assert_no_difference("Category.count") do
+      post "/api/categories",
+        params: { category: { name: categories(:one).name } },
+        as: :json
+    end
+
+    assert_response :unprocessable_entity
+
+    response_json = JSON.parse(response.body)
+
+    assert_includes response_json["errors"], "Name has already been taken"
+  end
+end

--- a/backend/test/controllers/api/spots_controller_test.rb
+++ b/backend/test/controllers/api/spots_controller_test.rb
@@ -1,0 +1,88 @@
+require "test_helper"
+
+class Api::SpotsControllerTest < ActionDispatch::IntegrationTest
+  test "creates a spot" do
+    assert_difference("Spot.count", 1) do
+      post "/api/spots",
+        params: {
+          spot: {
+            category_id: categories(:one).id,
+            name: "Local Sento",
+            note: "Open late",
+            url: "https://example.com/sento",
+            status: "want_to_go",
+            visited_on: "2026-04-09"
+          }
+        },
+        as: :json
+    end
+
+    assert_response :created
+
+    response_json = JSON.parse(response.body)
+
+    assert_equal "Local Sento", response_json["name"]
+    assert_equal "want_to_go", response_json["status"]
+    assert_equal categories(:one).id, response_json["category_id"]
+  end
+
+  test "returns errors when spot is invalid" do
+    assert_no_difference("Spot.count") do
+      post "/api/spots",
+        params: {
+          spot: {
+            category_id: categories(:one).id,
+            name: "",
+            status: "want_to_go"
+          }
+        },
+        as: :json
+    end
+
+    assert_response :unprocessable_entity
+
+    response_json = JSON.parse(response.body)
+
+    assert_includes response_json["errors"], "Name can't be blank"
+  end
+
+  test "returns errors when spot status is unsupported" do
+    assert_no_difference("Spot.count") do
+      post "/api/spots",
+        params: {
+          spot: {
+            category_id: categories(:one).id,
+            name: "Test Spot",
+            status: "archived"
+          }
+        },
+        as: :json
+    end
+
+    assert_response :unprocessable_entity
+
+    response_json = JSON.parse(response.body)
+
+    assert_includes response_json["errors"], "Status is not included in the list"
+  end
+
+  test "returns errors when category does not exist" do
+    assert_no_difference("Spot.count") do
+      post "/api/spots",
+        params: {
+          spot: {
+            category_id: -1,
+            name: "Ghost Spot",
+            status: "want_to_go"
+          }
+        },
+        as: :json
+    end
+
+    assert_response :unprocessable_entity
+
+    response_json = JSON.parse(response.body)
+
+    assert_includes response_json["errors"], "Category must exist"
+  end
+end


### PR DESCRIPTION
## 概要
  `Category` と `Spot` を作成する create API を追加し、あわせて正常系・異常系のテストを実装しました。

  ## 変更内容
  ### API実装
  - `POST /api/categories` を追加
  - `POST /api/spots` を追加
  - `Api::CategoriesController#create` を実装
  - `Api::SpotsController#create` を実装
  - strong parameters を設定
  - 保存成功時は `201 Created`、バリデーションエラー時は
  `422 Unprocessable Entity` を返すように実装

  ### ルーティング
  - `api` namespace 配下に `categories` / `spots` の
  create route を追加

  ### テスト
  - `Category` create API のテストを追加
    - 正常に作成できること
    - name が空の場合に `422` を返すこと
    - name が重複した場合に `422` を返すこと
  - `Spot` create API のテストを追加
    - 正常に作成できること
    - name が空の場合に `422` を返すこと
    - 不正な status の場合に `422` を返すこと
    - 存在しない category の場合に `422` を返すこと

  ## 目的
  SpotLog の基本機能であるデータ登録処理をAPIとして利用できるようにし、あわせてテストで挙動を担保するためです。

  ## 影響範囲
  - バックエンドAPI
  - ルーティング
  - Integration Test

  ## 補足
  今回の変更は以下の2コミットです。
  - `feat: add create endpoints for categories and spots`
  - `test: add create API tests for categories and spots`
closes #12 