### PR TITLE
feat: add spots index show api

### DIFF
--- a/backend/app/controllers/api/spots_controller.rb
+++ b/backend/app/controllers/api/spots_controller.rb
@@ -1,5 +1,9 @@
 module Api
   class SpotsController < ApplicationController
+    def index
+      spots = Spot.all
+      render json: spots, status: :ok
+    end
 
     def create
       spot = Spot.new(spot_params)
@@ -8,6 +12,16 @@ module Api
         render json: spot, status: :created
       else
         render json: { errors: spot.errors.full_messages }, status: :unprocessable_entity
+      end
+    end
+
+    def show
+      spot = Spot.find_by(id: params[:id])
+
+      if spot
+        render json: spot, status: :ok
+      else
+        render json: { errors: ["Spot not found"] }, status: :not_found
       end
     end
 

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -4,6 +4,6 @@ Rails.application.routes.draw do
 
   namespace :api do
     resources :categories, only: [:create]
-    resources :spots, only: [:create]
+    resources :spots, only: [:index, :create, :show]
   end
 end

--- a/backend/test/controllers/api/spots_controller_test.rb
+++ b/backend/test/controllers/api/spots_controller_test.rb
@@ -1,6 +1,17 @@
 require "test_helper"
 
 class Api::SpotsControllerTest < ActionDispatch::IntegrationTest
+  test "lists spots" do
+    get "/api/spots"
+
+    assert_response :ok
+
+    response_json = JSON.parse(response.body)
+
+    assert_equal 2, response_json.length
+    assert_equal [spots(:one).id, spots(:two).id].sort, response_json.map { |spot| spot["id"] }.sort
+  end
+
   test "creates a spot" do
     assert_difference("Spot.count", 1) do
       post "/api/spots",
@@ -24,6 +35,28 @@ class Api::SpotsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Local Sento", response_json["name"]
     assert_equal "want_to_go", response_json["status"]
     assert_equal categories(:one).id, response_json["category_id"]
+  end
+
+  test "shows a spot" do
+    get "/api/spots/#{spots(:one).id}"
+
+    assert_response :ok
+
+    response_json = JSON.parse(response.body)
+
+    assert_equal spots(:one).id, response_json["id"]
+    assert_equal spots(:one).name, response_json["name"]
+    assert_equal spots(:one).status, response_json["status"]
+  end
+
+  test "returns not found when spot does not exist" do
+    get "/api/spots/999999"
+
+    assert_response :not_found
+
+    response_json = JSON.parse(response.body)
+
+    assert_equal ["Spot not found"], response_json["errors"]
   end
 
   test "returns errors when spot is invalid" do


### PR DESCRIPTION
## 概要
Spot の一覧取得・詳細取得 API を追加し、あわせて正常系・異常系のテストを実装しました。

## 変更内容

### API実装
- `GET /api/spots` を追加
- `GET /api/spots/:id` を追加
- `Api::SpotsController#index` を実装
- `Api::SpotsController#show` を実装
- 一覧取得時に Spot の配列を JSON で返すように実装
- 詳細取得時に対象 Spot を JSON で返すように実装
- 存在しない Spot を指定した場合は `404 Not Found` を返すように実装

### ルーティング
- `api` namespace 配下に `spots` の `index` / `show` route を追加

### テスト
- Spot index API のテストを追加
  - 一覧取得で `200 OK` を返すこと
  - fixture の Spot が一覧に含まれていること

- Spot show API のテストを追加
  - 詳細取得で `200 OK` を返すこと
  - 指定した Spot の `id` / `name` / `status` が返ること
  - 存在しない Spot を指定した場合に `404 Not Found` を返すこと
  - エラーレスポンスとして `errors: ["Spot not found"]` を返すこと

## 目的
SpotLog の基本機能である「保存した Spot を一覧・詳細で見返す機能」を API として利用できるようにし、あわせてテストで取得系 API の挙動を担保するためです。

## 影響範囲
- バックエンドAPI
- ルーティング
- Integration Test

## 補足
今回の変更は以下のコミットです。

- `[feat: add index and show API for spots]`
- `[test: add index and show API tests for spots]`

closes #14 