### PR TITLE
feature: add categories index api

### DIFF
--- a/backend/app/controllers/api/categories_controller.rb
+++ b/backend/app/controllers/api/categories_controller.rb
@@ -1,6 +1,11 @@
 module Api
   class CategoriesController < ApplicationController
 
+    def index
+      categories = Category.all
+      render json: categories, status: :ok
+    end
+
     def create
       category = Category.new(category_params)
 

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   get "up" => "rails/health#show", as: :rails_health_check
 
   namespace :api do
-    resources :categories, only: [:create]
+    resources :categories, only: [:index, :create]
     resources :spots, only: [:index, :create, :show]
   end
 end

--- a/backend/test/controllers/api/categories_controller_test.rb
+++ b/backend/test/controllers/api/categories_controller_test.rb
@@ -1,6 +1,17 @@
 require "test_helper"
 
 class Api::CategoriesControllerTest < ActionDispatch::IntegrationTest
+  test "lists categories" do
+    get "/api/categories"
+
+    assert_response :ok
+
+    response_json = JSON.parse(response.body)
+
+    assert_equal 2, response_json.length
+    assert_equal [categories(:one).id, categories(:two).id].sort, response_json.map { |category| category["id"] }.sort
+  end
+
   test "creates a category" do
     assert_difference("Category.count", 1) do
       post "/api/categories",


### PR DESCRIPTION
 ## 概要
  categories の一覧取得APIを追加し、関連するコントローラテストを追加しました。

  ## 変更内容
  - `GET /api/categories` を追加
    - Category 一覧を JSON で返す
  - ルーティングを更新
    - `categories` に `index` を追加
  - コントローラテストを追加
    - 一覧取得の正常系
    - レスポンス件数と返却データを確認

  ## 確認ポイント
  - `GET /api/categories` でカテゴリ一覧を取得できること
  - レスポンスが `200 OK` であること
  - fixture の category が返却されること

  ## 変更ファイル
  - `backend/app/controllers/api/categories_controller.rb`
    - `index` アクションを追加
  - `backend/config/routes.rb`
    - `categories` に `index` ルートを追加
  - `backend/test/controllers/api/
  categories_controller_test.rb`
    - categories 一覧取得APIのテストを追加

  ## テスト
  - `bin/rails test test/controllers/api/
  categories_controller_test.rb`

closes #15 