### PR TITLE
Feature/18 add spots update delete api

### DIFF
--- a/backend/app/controllers/api/spots_controller.rb
+++ b/backend/app/controllers/api/spots_controller.rb
@@ -25,6 +25,28 @@ module Api
       end
     end
 
+    def update
+      spot = Spot.find_by(id: params[:id])
+
+      if spot.nil?
+        render json: { errors: ["Spot not found"] }, status: :not_found
+      elsif spot.update(spot_params)
+        render json: spot, status: :ok
+      else
+        render json: { errors: spot.errors.full_messages }, status: :unprocessable_entity
+      end
+    end
+
+    def destroy
+      spot = Spot.find_by(id: params[:id])
+      if spot.nil?
+        render json: { errors: ["Spot not found"] }, status: :not_found
+      else
+        spot.destroy
+        head :no_content
+      end
+    end
+
     private
 
     def spot_params

--- a/backend/app/controllers/api/spots_controller.rb
+++ b/backend/app/controllers/api/spots_controller.rb
@@ -16,38 +16,43 @@ module Api
     end
 
     def show
-      spot = Spot.find_by(id: params[:id])
+      find_spot
 
-      if spot
-        render json: spot, status: :ok
+      if @spot
+        render json: @spot, status: :ok
       else
         render json: { errors: ["Spot not found"] }, status: :not_found
       end
     end
 
     def update
-      spot = Spot.find_by(id: params[:id])
+      find_spot
 
-      if spot.nil?
+      if @spot.nil?
         render json: { errors: ["Spot not found"] }, status: :not_found
-      elsif spot.update(spot_params)
-        render json: spot, status: :ok
+      elsif @spot.update(spot_params)
+        render json: @spot, status: :ok
       else
-        render json: { errors: spot.errors.full_messages }, status: :unprocessable_entity
+        render json: { errors: @spot.errors.full_messages }, status: :unprocessable_entity
       end
     end
 
     def destroy
-      spot = Spot.find_by(id: params[:id])
-      if spot.nil?
+      find_spot
+
+      if @spot.nil?
         render json: { errors: ["Spot not found"] }, status: :not_found
       else
-        spot.destroy
+        @spot.destroy
         head :no_content
       end
     end
 
     private
+
+    def find_spot
+      @spot = Spot.find_by(id: params[:id])
+    end
 
     def spot_params
       params.require(:spot).permit(:category_id, :name, :note, :url, :status, :visited_on)

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -4,6 +4,6 @@ Rails.application.routes.draw do
 
   namespace :api do
     resources :categories, only: [:index, :create]
-    resources :spots, only: [:index, :create, :show]
+    resources :spots, only: [:index, :create, :show, :update, :destroy]
   end
 end

--- a/backend/test/controllers/api/spots_controller_test.rb
+++ b/backend/test/controllers/api/spots_controller_test.rb
@@ -59,6 +59,62 @@ class Api::SpotsControllerTest < ActionDispatch::IntegrationTest
     assert_equal ["Spot not found"], response_json["errors"]
   end
 
+  test "updates a spot" do
+    patch "/api/spots/#{spots(:one).id}",
+      params: {
+        spot: {
+          name: "Updated Cafe",
+          status: "visited"
+        }
+      },
+      as: :json
+
+    assert_response :ok
+
+    response_json = JSON.parse(response.body)
+
+    assert_equal "Updated Cafe", response_json["name"]
+    assert_equal "visited", response_json["status"]
+    assert_equal "Updated Cafe", spots(:one).reload.name
+    assert_equal "visited", spots(:one).reload.status
+  end
+
+  test "returns not found when updating a non-existent spot" do
+    patch "/api/spots/999999",
+      params: {
+        spot: {
+          name: "Updated Cafe"
+        }
+      },
+      as: :json
+
+    assert_response :not_found
+
+    response_json = JSON.parse(response.body)
+
+    assert_equal ["Spot not found"], response_json["errors"]
+  end
+
+  test "destroys a spot" do
+    assert_difference("Spot.count", -1) do
+      delete "/api/spots/#{spots(:one).id}"
+    end
+
+    assert_response :no_content
+  end
+
+  test "returns not found when deleting a non-existent spot" do
+    assert_no_difference("Spot.count") do
+      delete "/api/spots/999999"
+    end
+
+    assert_response :not_found
+
+    response_json = JSON.parse(response.body)
+
+    assert_equal ["Spot not found"], response_json["errors"]
+  end
+
   test "returns errors when spot is invalid" do
     assert_no_difference("Spot.count") do
       post "/api/spots",


### PR DESCRIPTION
## 概要
  spots の更新APIと削除APIを追加し、あわせて取得処理の整理
  と関連テストの追加を行いました。

  ## 変更内容
  - `PATCH /api/spots/:id` を追加
    - Spot を更新できるように変更
    - 存在しない Spot を指定した場合は `404 Not Found` を
  返す
  - `DELETE /api/spots/:id` を追加
    - Spot を削除できるように変更
    - 存在しない Spot を指定した場合は `404 Not Found` を
  返す
  - `SpotsController` の取得処理を整理
    - `find_spot` を切り出して `show`, `update`, `destroy`
  の重複を削減
  - コントローラテストを追加
    - update の正常系
    - update の 404
    - destroy の正常系
    - destroy の 404

  ## 確認ポイント
  - `PATCH /api/spots/:id` で Spot を更新できること
  - 存在しない ID で更新した場合に `404` が返ること
  - `DELETE /api/spots/:id` で Spot を削除できること
  - 存在しない ID で削除した場合に `404` が返ること

  ## 変更ファイル
  - `backend/app/controllers/api/spots_controller.rb`
    - `update`, `destroy` を追加
    - `find_spot` を切り出して処理を整理
  - `backend/config/routes.rb`
    - `spots` に `update`, `destroy` ルートを追加
  - `backend/test/controllers/api/
  spots_controller_test.rb`
    - update / destroy API のテストを追加

  ## テスト
  - `bin/rails test test/controllers/api/
  spots_controller_test.rb`

closes #18 