### PR TITLE
Feature/20 filter spots by category

### DIFF
--- a/backend/app/controllers/api/spots_controller.rb
+++ b/backend/app/controllers/api/spots_controller.rb
@@ -1,8 +1,7 @@
 module Api
   class SpotsController < ApplicationController
     def index
-      spots = Spot.all
-      render json: spots, status: :ok
+      render json: spots_for_index, status: :ok
     end
 
     def create
@@ -49,6 +48,13 @@ module Api
     end
 
     private
+
+    def spots_for_index
+      spots = Spot.all
+      return spots unless params[:category_id].present?
+
+      spots.where(category_id: params[:category_id])
+    end
 
     def find_spot
       @spot = Spot.find_by(id: params[:id])

--- a/backend/app/controllers/api/spots_controller.rb
+++ b/backend/app/controllers/api/spots_controller.rb
@@ -1,5 +1,7 @@
 module Api
   class SpotsController < ApplicationController
+    before_action :find_spot, only: [:show, :update, :destroy]
+
     def index
       render json: spots_for_index, status: :ok
     end
@@ -15,8 +17,6 @@ module Api
     end
 
     def show
-      find_spot
-
       if @spot
         render json: @spot, status: :ok
       else
@@ -25,8 +25,6 @@ module Api
     end
 
     def update
-      find_spot
-
       if @spot.nil?
         render json: { errors: ["Spot not found"] }, status: :not_found
       elsif @spot.update(spot_params)
@@ -37,8 +35,6 @@ module Api
     end
 
     def destroy
-      find_spot
-
       if @spot.nil?
         render json: { errors: ["Spot not found"] }, status: :not_found
       else

--- a/backend/test/controllers/api/spots_controller_test.rb
+++ b/backend/test/controllers/api/spots_controller_test.rb
@@ -12,6 +12,27 @@ class Api::SpotsControllerTest < ActionDispatch::IntegrationTest
     assert_equal [spots(:one).id, spots(:two).id].sort, response_json.map { |spot| spot["id"] }.sort
   end
 
+  test "filters spots by category_id" do
+    get "/api/spots", params: { category_id: categories(:one).id }
+
+    assert_response :ok
+
+    response_json = JSON.parse(response.body)
+
+    assert_equal 1, response_json.length
+    assert_equal [spots(:one).id], response_json.map { |spot| spot["id"] }
+  end
+
+  test "returns an empty array when no spots match the category filter" do
+    get "/api/spots", params: { category_id: 999999 }
+
+    assert_response :ok
+
+    response_json = JSON.parse(response.body)
+
+    assert_equal [], response_json
+  end
+
   test "creates a spot" do
     assert_difference("Spot.count", 1) do
       post "/api/spots",


### PR DESCRIPTION
## 概要
`GET /api/spots` に `category_id` フィルタを追加し、カテゴリごとの絞り込みができるようにしました。  
あわせて、`SpotsController` の Spot取得処理を `before_action` で整理しました。

## 背景
Spot 一覧APIは全件取得のみで、カテゴリごとの絞り込みができませんでした。  
MVP要件としてカテゴリ単位で Spot を扱えるようにする必要があったため、この変更を行いました。  
また、関連する `SpotsController` の取得処理もあわせて整理しました。

## 変更内容
- `GET /api/spots?category_id=...` でカテゴリごとの絞り込みを追加
- `category_id` 未指定時は従来どおり全件取得するようにした
- 該当する Spot がない場合は空配列を返すようにした
- `show` / `update` / `destroy` の Spot取得処理を `before_action` に整理した

## 確認ポイント
- `GET /api/spots` で全件取得できること
- `GET /api/spots?category_id=...` で該当カテゴリの Spot のみ返ること
- 存在しない `category_id` を指定した場合に `200 OK` で空配列が返ること
- `show` / `update` / `destroy` の既存挙動が変わっていないこと

## テスト
- 実行したテストコマンド
  - `bin/rails test`
- 確認した内容
  - `category_id` フィルタの追加テストが通ること
  - 既存の Spot API テストが通ること
- 必要なら未確認事項
  - なし

## 補足
- 一覧APIのフィルタでは、存在しない `category_id` に対してもエラーではなく空配列を返す方針としています
- `before_action` への整理は、Issue 20 の関連リファクタとして含めています

closes #20 
closes #21 
