### PR TITLE
Feature/23 add categories update delete api

### DIFF
--- a/backend/app/controllers/api/categories_controller.rb
+++ b/backend/app/controllers/api/categories_controller.rb
@@ -1,6 +1,6 @@
 module Api
   class CategoriesController < ApplicationController
-
+    before_action :find_category, only: [ :update, :destroy ]
     def index
       categories = Category.all
       render json: categories, status: :ok
@@ -16,7 +16,32 @@ module Api
       end
     end
 
+    def update
+      if @category.nil?
+        render json: { errors: [ "Category not found" ] }, status: :not_found
+      elsif @category.update(category_params)
+        render json: @category, status: :ok
+      else
+        render json: { errors: @category.errors.full_messages }, status: :unprocessable_entity
+      end
+    end
+
+    def destroy
+      if @category.nil?
+        render json: { errors: [ "Category not found" ] }, status: :not_found
+      else
+        @category.destroy
+        head :no_content
+      end
+    rescue ActiveRecord::DeleteRestrictionError
+      render json: { errors: [ "Cannot delete category with associated spots" ] }, status: :unprocessable_entity
+    end
+
     private
+
+    def find_category
+      @category = Category.find_by(id: params[:id])
+    end
 
     def category_params
       params.require(:category).permit(:name)

--- a/backend/app/controllers/api/spots_controller.rb
+++ b/backend/app/controllers/api/spots_controller.rb
@@ -1,6 +1,6 @@
 module Api
   class SpotsController < ApplicationController
-    before_action :find_spot, only: [:show, :update, :destroy]
+    before_action :find_spot, only: [ :show, :update, :destroy ]
 
     def index
       render json: spots_for_index, status: :ok
@@ -20,13 +20,13 @@ module Api
       if @spot
         render json: @spot, status: :ok
       else
-        render json: { errors: ["Spot not found"] }, status: :not_found
+        render json: { errors: [ "Spot not found" ] }, status: :not_found
       end
     end
 
     def update
       if @spot.nil?
-        render json: { errors: ["Spot not found"] }, status: :not_found
+        render json: { errors: [ "Spot not found" ] }, status: :not_found
       elsif @spot.update(spot_params)
         render json: @spot, status: :ok
       else
@@ -36,7 +36,7 @@ module Api
 
     def destroy
       if @spot.nil?
-        render json: { errors: ["Spot not found"] }, status: :not_found
+        render json: { errors: [ "Spot not found" ] }, status: :not_found
       else
         @spot.destroy
         head :no_content

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,9 +1,8 @@
 Rails.application.routes.draw do
-
   get "up" => "rails/health#show", as: :rails_health_check
 
   namespace :api do
-    resources :categories, only: [:index, :create]
-    resources :spots, only: [:index, :create, :show, :update, :destroy]
+    resources :categories, only: [ :index, :create, :update, :destroy ]
+    resources :spots, only: [ :index, :create, :show, :update, :destroy ]
   end
 end

--- a/backend/test/controllers/api/categories_controller_test.rb
+++ b/backend/test/controllers/api/categories_controller_test.rb
@@ -9,7 +9,7 @@ class Api::CategoriesControllerTest < ActionDispatch::IntegrationTest
     response_json = JSON.parse(response.body)
 
     assert_equal 2, response_json.length
-    assert_equal [categories(:one).id, categories(:two).id].sort, response_json.map { |category| category["id"] }.sort
+    assert_equal [ categories(:one).id, categories(:two).id ].sort, response_json.map { |category| category["id"] }.sort
   end
 
   test "creates a category" do
@@ -52,5 +52,76 @@ class Api::CategoriesControllerTest < ActionDispatch::IntegrationTest
     response_json = JSON.parse(response.body)
 
     assert_includes response_json["errors"], "Name has already been taken"
+  end
+
+  test "updates a category" do
+    patch "/api/categories/#{categories(:one).id}",
+      params: { category: { name: "Coffee Shop" } },
+      as: :json
+
+    assert_response :ok
+
+    response_json = JSON.parse(response.body)
+
+    assert_equal "Coffee Shop", response_json["name"]
+    assert_equal "Coffee Shop", categories(:one).reload.name
+  end
+
+  test "returns not found when updating a non-existent category" do
+    patch "/api/categories/999999",
+      params: { category: { name: "Coffee Shop" } },
+      as: :json
+
+    assert_response :not_found
+
+    response_json = JSON.parse(response.body)
+
+    assert_equal [ "Category not found" ], response_json["errors"]
+  end
+
+  test "returns errors when updating a category with duplicate name" do
+    patch "/api/categories/#{categories(:one).id}",
+      params: { category: { name: categories(:two).name } },
+      as: :json
+
+    assert_response :unprocessable_entity
+
+    response_json = JSON.parse(response.body)
+
+    assert_includes response_json["errors"], "Name has already been taken"
+  end
+
+  test "destroys a category without associated spots" do
+    category = Category.create!(name: "Hot Spring")
+
+    assert_difference("Category.count", -1) do
+      delete "/api/categories/#{category.id}"
+    end
+
+    assert_response :no_content
+  end
+
+  test "returns not found when deleting a non-existent category" do
+    assert_no_difference("Category.count") do
+      delete "/api/categories/999999"
+    end
+
+    assert_response :not_found
+
+    response_json = JSON.parse(response.body)
+
+    assert_equal [ "Category not found" ], response_json["errors"]
+  end
+
+  test "returns errors when deleting a category with associated spots" do
+    assert_no_difference("Category.count") do
+      delete "/api/categories/#{categories(:one).id}"
+    end
+
+    assert_response :unprocessable_entity
+
+    response_json = JSON.parse(response.body)
+
+    assert_equal [ "Cannot delete category with associated spots" ], response_json["errors"]
   end
 end

--- a/backend/test/controllers/api/spots_controller_test.rb
+++ b/backend/test/controllers/api/spots_controller_test.rb
@@ -9,7 +9,7 @@ class Api::SpotsControllerTest < ActionDispatch::IntegrationTest
     response_json = JSON.parse(response.body)
 
     assert_equal 2, response_json.length
-    assert_equal [spots(:one).id, spots(:two).id].sort, response_json.map { |spot| spot["id"] }.sort
+    assert_equal [ spots(:one).id, spots(:two).id ].sort, response_json.map { |spot| spot["id"] }.sort
   end
 
   test "filters spots by category_id" do
@@ -20,7 +20,7 @@ class Api::SpotsControllerTest < ActionDispatch::IntegrationTest
     response_json = JSON.parse(response.body)
 
     assert_equal 1, response_json.length
-    assert_equal [spots(:one).id], response_json.map { |spot| spot["id"] }
+    assert_equal [ spots(:one).id ], response_json.map { |spot| spot["id"] }
   end
 
   test "returns an empty array when no spots match the category filter" do
@@ -77,7 +77,7 @@ class Api::SpotsControllerTest < ActionDispatch::IntegrationTest
 
     response_json = JSON.parse(response.body)
 
-    assert_equal ["Spot not found"], response_json["errors"]
+    assert_equal [ "Spot not found" ], response_json["errors"]
   end
 
   test "updates a spot" do
@@ -113,7 +113,7 @@ class Api::SpotsControllerTest < ActionDispatch::IntegrationTest
 
     response_json = JSON.parse(response.body)
 
-    assert_equal ["Spot not found"], response_json["errors"]
+    assert_equal [ "Spot not found" ], response_json["errors"]
   end
 
   test "destroys a spot" do
@@ -133,7 +133,7 @@ class Api::SpotsControllerTest < ActionDispatch::IntegrationTest
 
     response_json = JSON.parse(response.body)
 
-    assert_equal ["Spot not found"], response_json["errors"]
+    assert_equal [ "Spot not found" ], response_json["errors"]
   end
 
   test "returns errors when spot is invalid" do


### PR DESCRIPTION
## 背景
Category は現状 `index` と `create` のみで、CRUD が揃っていません。
関連する Spot を持つため、更新・削除時の扱いも明確にする必要があります。

## 目的
Category の更新・削除 API を追加し、関連付きデータ削除時の挙動を明確にする。

## やること
- [x] `PATCH /api/categories/:id` を追加
- [x] `DELETE /api/categories/:id` を追加
- [ ] `GET /api/categories/:id` の追加
- [x] Spot が紐づく Category を削除するときの挙動を明確化
- [x] テストを追加

## 完了条件
- [x] Category の更新ができる
- [x] Category の削除ができる
- [x] 関連付き削除時の仕様が明確
- [x] テストが成功する

## 対象範囲
- frontend: なし
- backend: `CategoriesController`、`routes`、controller test
- db: なし
- infra: なし

## 影響範囲
- API: categories 系エンドポイント
- model association: `Category has_many :spots`
- test: categories controller test
- formatting: `spots_controller` と spots controller test に軽微な RuboCop 整形

## 補足
- `Category` の削除は既存の `dependent: :restrict_with_exception` を利用
- Spot が紐づく Category を削除しようとした場合は `422 Unprocessable Entity` を返す
- `GET /api/categories/:id` は MVP 必須ではないため今回のPRでは対象外
- 実行確認:
  - `docker compose exec backend bundle exec rails test`
  - `docker compose exec backend bundle exec rubocop`


closes #23 
