### PR TITLE
Feature/22 add spot sorting

### DIFF
--- a/backend/app/controllers/api/spots_controller.rb
+++ b/backend/app/controllers/api/spots_controller.rb
@@ -1,5 +1,6 @@
 module Api
   class SpotsController < ApplicationController
+    before_action :validate_sort_param, only: [ :index ]
     before_action :find_spot, only: [ :show, :update, :destroy ]
 
     def index
@@ -47,13 +48,21 @@ module Api
 
     def spots_for_index
       spots = Spot.all
-      return spots unless params[:category_id].present?
+      spots = spots.where(category_id: params[:category_id]) if params[:category_id].present?
 
-      spots.where(category_id: params[:category_id])
+      sort_order = Spot.sort_order_for(params[:sort])
+      sort_order ? spots.order(sort_order) : spots
     end
 
     def find_spot
       @spot = Spot.find_by(id: params[:id])
+    end
+
+    def validate_sort_param
+      return unless params[:sort].present?
+      return if Spot.sort_order_for(params[:sort])
+
+      render json: { errors: [ "Invalid sort parameter" ] }, status: :bad_request
     end
 
     def spot_params

--- a/backend/app/models/spot.rb
+++ b/backend/app/models/spot.rb
@@ -1,4 +1,9 @@
 class Spot < ApplicationRecord
+  SORT_ORDERS = {
+    "name_asc" => { name: :asc },
+    "created_at_desc" => { created_at: :desc }
+  }.freeze
+
   enum :status, {
     want_to_go: "want_to_go",
     visited: "visited"
@@ -8,4 +13,8 @@ class Spot < ApplicationRecord
 
   validates :name, presence: true
   validates :status, presence: true
+
+  def self.sort_order_for(sort)
+    SORT_ORDERS[sort]
+  end
 end

--- a/backend/test/controllers/api/spots_controller_test.rb
+++ b/backend/test/controllers/api/spots_controller_test.rb
@@ -33,6 +33,62 @@ class Api::SpotsControllerTest < ActionDispatch::IntegrationTest
     assert_equal [], response_json
   end
 
+  test "sorts spots by name in ascending order" do
+    spot_c = Spot.create!(
+      category: categories(:one),
+      name: "Zebra Cafe",
+      status: "want_to_go"
+    )
+    spot_a = Spot.create!(
+      category: categories(:one),
+      name: "Apple Cafe",
+      status: "want_to_go"
+    )
+
+    get "/api/spots", params: { sort: "name_asc" }
+
+    assert_response :ok
+
+    response_json = JSON.parse(response.body)
+
+    assert_equal [ spot_a.id, spots(:one).id, spots(:two).id, spot_c.id ], response_json.map { |spot| spot["id"] }
+  end
+
+  test "sorts spots by created_at in descending order" do
+    older_spot = Spot.create!(
+      category: categories(:one),
+      name: "Older Cafe",
+      status: "want_to_go",
+      created_at: 2.days.ago,
+      updated_at: 2.days.ago
+    )
+    newer_spot = Spot.create!(
+      category: categories(:one),
+      name: "Newer Cafe",
+      status: "want_to_go",
+      created_at: 1.hour.ago,
+      updated_at: 1.hour.ago
+    )
+
+    get "/api/spots", params: { sort: "created_at_desc" }
+
+    assert_response :ok
+
+    response_json = JSON.parse(response.body)
+
+    assert_operator response_json.map { |spot| spot["id"] }.index(newer_spot.id), :<, response_json.map { |spot| spot["id"] }.index(older_spot.id)
+  end
+
+  test "returns bad request when sort parameter is invalid" do
+    get "/api/spots", params: { sort: "name_desc" }
+
+    assert_response :bad_request
+
+    response_json = JSON.parse(response.body)
+
+    assert_equal [ "Invalid sort parameter" ], response_json["errors"]
+  end
+
   test "creates a spot" do
     assert_difference("Spot.count", 1) do
       post "/api/spots",


### PR DESCRIPTION
## 概要
Issue #22 の対応として、`GET /api/spots` に `sort` クエリパラメータを追加し、一覧APIの並び順を制御できるようにしました。

## 変更内容
- `sort` パラメータによる並び替えを追加
- 対応する並び順を最小構成で実装
  - `name_asc`
  - `created_at_desc`
- 不正な `sort` 値に対して `400 Bad Request` を返すように変更
- 並び替えに関する request test を追加

## 実装方針
- 並び順の定義は `Spot` model に集約
- `SpotsController#index` では
  - `category_id` での絞り込み
  - `sort` による並び替え
  を順に適用
- 許可していない `sort` 値は事前に検証してエラーを返す

## 動作例
- `GET /api/spots?sort=name_asc`
- `GET /api/spots?sort=created_at_desc`
- `GET /api/spots?category_id=1&sort=name_asc`

## 変更ファイル
- `backend/app/controllers/api/spots_controller.rb`
- `backend/app/models/spot.rb`
- `backend/test/controllers/api/spots_controller_test.rb`

## テスト
- `docker compose exec backend bundle exec rails test`
- `docker compose exec backend bundle exec rubocop`

## 補足
今回は学習段階と Issue のスコープに合わせて、並び順は 2 種類に絞って実装しています。
今後必要になれば、許可する `sort` を追加して拡張できる構成です。

closes #22 