### PR TITLE
feat: make api json responses explicit

### DIFF
--- a/backend/app/controllers/api/categories_controller.rb
+++ b/backend/app/controllers/api/categories_controller.rb
@@ -1,16 +1,17 @@
 module Api
   class CategoriesController < ApplicationController
     before_action :find_category, only: [ :update, :destroy ]
+
     def index
       categories = Category.all
-      render json: categories, status: :ok
+      render json: categories.map { |category| category_response(category) }, status: :ok
     end
 
     def create
       category = Category.new(category_params)
 
       if category.save
-        render json: category, status: :created
+        render json: category_response(category), status: :created
       else
         render json: { errors: category.errors.full_messages }, status: :unprocessable_entity
       end
@@ -20,7 +21,7 @@ module Api
       if @category.nil?
         render json: { errors: [ "Category not found" ] }, status: :not_found
       elsif @category.update(category_params)
-        render json: @category, status: :ok
+        render json: category_response(@category), status: :ok
       else
         render json: { errors: @category.errors.full_messages }, status: :unprocessable_entity
       end
@@ -45,6 +46,15 @@ module Api
 
     def category_params
       params.require(:category).permit(:name)
+    end
+
+    def category_response(category)
+      category.as_json(only: %i[
+        id
+        name
+        created_at
+        updated_at
+      ])
     end
   end
 end

--- a/backend/app/controllers/api/spots_controller.rb
+++ b/backend/app/controllers/api/spots_controller.rb
@@ -4,14 +4,14 @@ module Api
     before_action :find_spot, only: [ :show, :update, :destroy ]
 
     def index
-      render json: spots_for_index, status: :ok
+      render json: spots_for_index.map { |spot| spot_response(spot) }, status: :ok
     end
 
     def create
       spot = Spot.new(spot_params)
 
       if spot.save
-        render json: spot, status: :created
+        render json: spot_response(spot), status: :created
       else
         render json: { errors: spot.errors.full_messages }, status: :unprocessable_entity
       end
@@ -19,7 +19,7 @@ module Api
 
     def show
       if @spot
-        render json: @spot, status: :ok
+        render json: spot_response(@spot), status: :ok
       else
         render json: { errors: [ "Spot not found" ] }, status: :not_found
       end
@@ -29,7 +29,7 @@ module Api
       if @spot.nil?
         render json: { errors: [ "Spot not found" ] }, status: :not_found
       elsif @spot.update(spot_params)
-        render json: @spot, status: :ok
+        render json: spot_response(@spot), status: :ok
       else
         render json: { errors: @spot.errors.full_messages }, status: :unprocessable_entity
       end
@@ -67,6 +67,20 @@ module Api
 
     def spot_params
       params.require(:spot).permit(:category_id, :name, :note, :url, :status, :visited_on)
+    end
+
+    def spot_response(spot)
+      spot.as_json(only: %i[
+        id
+        category_id
+        name
+        note
+        url
+        status
+        visited_on
+        created_at
+        updated_at
+      ])
     end
   end
 end

--- a/backend/test/controllers/api/categories_controller_test.rb
+++ b/backend/test/controllers/api/categories_controller_test.rb
@@ -1,6 +1,13 @@
 require "test_helper"
 
 class Api::CategoriesControllerTest < ActionDispatch::IntegrationTest
+  CATEGORY_RESPONSE_KEYS = %w[
+    id
+    name
+    created_at
+    updated_at
+  ].freeze
+
   test "lists categories" do
     get "/api/categories"
 
@@ -10,6 +17,7 @@ class Api::CategoriesControllerTest < ActionDispatch::IntegrationTest
 
     assert_equal 2, response_json.length
     assert_equal [ categories(:one).id, categories(:two).id ].sort, response_json.map { |category| category["id"] }.sort
+    assert_equal CATEGORY_RESPONSE_KEYS.sort, response_json.first.keys.sort
   end
 
   test "creates a category" do
@@ -24,6 +32,7 @@ class Api::CategoriesControllerTest < ActionDispatch::IntegrationTest
     response_json = JSON.parse(response.body)
 
     assert_equal "Ramen", response_json["name"]
+    assert_equal CATEGORY_RESPONSE_KEYS.sort, response_json.keys.sort
   end
 
   test "returns errors when category is invalid" do
@@ -64,6 +73,7 @@ class Api::CategoriesControllerTest < ActionDispatch::IntegrationTest
     response_json = JSON.parse(response.body)
 
     assert_equal "Coffee Shop", response_json["name"]
+    assert_equal CATEGORY_RESPONSE_KEYS.sort, response_json.keys.sort
     assert_equal "Coffee Shop", categories(:one).reload.name
   end
 

--- a/backend/test/controllers/api/spots_controller_test.rb
+++ b/backend/test/controllers/api/spots_controller_test.rb
@@ -1,6 +1,18 @@
 require "test_helper"
 
 class Api::SpotsControllerTest < ActionDispatch::IntegrationTest
+  SPOT_RESPONSE_KEYS = %w[
+    id
+    category_id
+    name
+    note
+    url
+    status
+    visited_on
+    created_at
+    updated_at
+  ].freeze
+
   test "lists spots" do
     get "/api/spots"
 
@@ -10,6 +22,7 @@ class Api::SpotsControllerTest < ActionDispatch::IntegrationTest
 
     assert_equal 2, response_json.length
     assert_equal [ spots(:one).id, spots(:two).id ].sort, response_json.map { |spot| spot["id"] }.sort
+    assert_equal SPOT_RESPONSE_KEYS.sort, response_json.first.keys.sort
   end
 
   test "filters spots by category_id" do
@@ -21,6 +34,7 @@ class Api::SpotsControllerTest < ActionDispatch::IntegrationTest
 
     assert_equal 1, response_json.length
     assert_equal [ spots(:one).id ], response_json.map { |spot| spot["id"] }
+    assert_equal SPOT_RESPONSE_KEYS.sort, response_json.first.keys.sort
   end
 
   test "returns an empty array when no spots match the category filter" do
@@ -52,6 +66,7 @@ class Api::SpotsControllerTest < ActionDispatch::IntegrationTest
     response_json = JSON.parse(response.body)
 
     assert_equal [ spot_a.id, spots(:one).id, spots(:two).id, spot_c.id ], response_json.map { |spot| spot["id"] }
+    assert_equal SPOT_RESPONSE_KEYS.sort, response_json.first.keys.sort
   end
 
   test "sorts spots by created_at in descending order" do
@@ -112,6 +127,7 @@ class Api::SpotsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Local Sento", response_json["name"]
     assert_equal "want_to_go", response_json["status"]
     assert_equal categories(:one).id, response_json["category_id"]
+    assert_equal SPOT_RESPONSE_KEYS.sort, response_json.keys.sort
   end
 
   test "shows a spot" do
@@ -124,6 +140,7 @@ class Api::SpotsControllerTest < ActionDispatch::IntegrationTest
     assert_equal spots(:one).id, response_json["id"]
     assert_equal spots(:one).name, response_json["name"]
     assert_equal spots(:one).status, response_json["status"]
+    assert_equal SPOT_RESPONSE_KEYS.sort, response_json.keys.sort
   end
 
   test "returns not found when spot does not exist" do
@@ -152,6 +169,7 @@ class Api::SpotsControllerTest < ActionDispatch::IntegrationTest
 
     assert_equal "Updated Cafe", response_json["name"]
     assert_equal "visited", response_json["status"]
+    assert_equal SPOT_RESPONSE_KEYS.sort, response_json.keys.sort
     assert_equal "Updated Cafe", spots(:one).reload.name
     assert_equal "visited", spots(:one).reload.status
   end


### PR DESCRIPTION
## 概要
Issue #26 の対応として、Spot / Category の成功レスポンスを明示的に整形するようにしました。

これまで `render json: model` に任せていた箇所を、返却キーを明示する形に変更しています。
あわせて、controller test でもレスポンスのキーを検証するようにして、APIレスポンスの形をテストで担保しました。

## 変更内容
- Spot の一覧・詳細・作成・更新で返すJSONを `spot_response` 経由に統一
- Category の一覧・作成・更新で返すJSONを `category_response` 経由に統一
- `render json: model` 任せではなく、`as_json(only: ...)` で返却キーを明示
- controller test にレスポンスキーの検証を追加

## 返却キー
### Spot
- `id`
- `category_id`
- `name`
- `note`
- `url`
- `status`
- `visited_on`
- `created_at`
- `updated_at`

### Category
- `id`
- `name`
- `created_at`
- `updated_at`

## 影響範囲
- `GET /api/spots`
- `GET /api/spots/:id`
- `POST /api/spots`
- `PATCH /api/spots/:id`
- `GET /api/categories`
- `POST /api/categories`
- `PATCH /api/categories/:id`
- spots / categories controller test

## 確認したこと
- 成功レスポンスが明示したキーのみを返すこと
- 既存のエラーレスポンス形式 `{ errors: [...] }` に影響がないこと
- controller test が通ること
- Rubocop が通ること

## 実行コマンド
```bash
docker compose exec backend bundle exec rails test test/controllers/api/spots_controller_test.rb test/controllers/api/categories_controller_test.rb
docker compose exec backend bundle exec rubocop app/controllers/api/spots_controller.rb app/controllers/api/categories_controller.rb test/controllers/api/spots_controller_test.rb test/controllers/api/categories_controller_test.rb
```

closes #26 