### PR TITLE
Feature/33 add spot user ownership

### DIFF
--- a/backend/app/controllers/api/spots_controller.rb
+++ b/backend/app/controllers/api/spots_controller.rb
@@ -66,13 +66,14 @@ module Api
     end
 
     def spot_params
-      params.require(:spot).permit(:category_id, :name, :note, :url, :status, :visited_on)
+      params.require(:spot).permit(:category_id, :name, :note, :url, :status, :visited_on, :user_id)
     end
 
     def spot_response(spot)
       spot.as_json(only: %i[
         id
         category_id
+        user_id
         name
         note
         url

--- a/backend/app/models/spot.rb
+++ b/backend/app/models/spot.rb
@@ -10,6 +10,7 @@ class Spot < ApplicationRecord
   }, validate: true
 
   belongs_to :category
+  belongs_to :user
 
   validates :name, presence: true
   validates :status, presence: true

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -1,0 +1,5 @@
+class User < ApplicationRecord
+  has_many :spots, dependent: :destroy
+
+  validates :name, presence: true
+end

--- a/backend/db/migrate/20260420022045_create_users.rb
+++ b/backend/db/migrate/20260420022045_create_users.rb
@@ -1,0 +1,9 @@
+class CreateUsers < ActiveRecord::Migration[8.1]
+  def change
+    create_table :users do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/backend/db/migrate/20260420022108_add_user_to_spots.rb
+++ b/backend/db/migrate/20260420022108_add_user_to_spots.rb
@@ -1,0 +1,5 @@
+class AddUserToSpots < ActiveRecord::Migration[8.1]
+  def change
+    add_reference :spots, :user, foreign_key: true
+  end
+end

--- a/backend/db/migrate/20260420022607_backfill_user_id_on_spots.rb
+++ b/backend/db/migrate/20260420022607_backfill_user_id_on_spots.rb
@@ -1,0 +1,22 @@
+class BackfillUserIdOnSpots < ActiveRecord::Migration[8.1]
+  class MigrationUser < ApplicationRecord
+    self.table_name = "users"
+  end
+
+  class MigrationSpot < ApplicationRecord
+    self.table_name = "spots"
+  end
+
+  def up
+    default_user = MigrationUser.find_or_create_by!(name: "Default User")
+    MigrationSpot.where(user_id: nil).update_all(user_id: default_user.id)
+  end
+
+  def down
+    default_user = MigrationUser.find_by(name: "Default User")
+    return unless default_user
+
+    MigrationSpot.where(user_id: default_user.id).update_all(user_id: nil)
+    default_user.destroy!
+  end
+end

--- a/backend/db/migrate/20260420022731_change_user_id_null_on_spots.rb
+++ b/backend/db/migrate/20260420022731_change_user_id_null_on_spots.rb
@@ -1,0 +1,5 @@
+class ChangeUserIdNullOnSpots < ActiveRecord::Migration[8.1]
+  def change
+    change_column_null :spots, :user_id, false
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_08_030757) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_20_022731) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -29,11 +29,20 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_030757) do
     t.string "status", default: "want_to_go", null: false
     t.datetime "updated_at", null: false
     t.string "url"
+    t.bigint "user_id", null: false
     t.date "visited_on"
     t.index ["category_id"], name: "index_spots_on_category_id"
     t.index ["status"], name: "index_spots_on_status"
+    t.index ["user_id"], name: "index_spots_on_user_id"
     t.check_constraint "status::text = ANY (ARRAY['want_to_go'::character varying, 'visited'::character varying]::text[])", name: "spots_status_check"
   end
 
+  create_table "users", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.datetime "updated_at", null: false
+  end
+
   add_foreign_key "spots", "categories"
+  add_foreign_key "spots", "users"
 end

--- a/backend/test/controllers/api/spots_controller_test.rb
+++ b/backend/test/controllers/api/spots_controller_test.rb
@@ -4,6 +4,7 @@ class Api::SpotsControllerTest < ActionDispatch::IntegrationTest
   SPOT_RESPONSE_KEYS = %w[
     id
     category_id
+    user_id
     name
     note
     url
@@ -49,11 +50,13 @@ class Api::SpotsControllerTest < ActionDispatch::IntegrationTest
 
   test "sorts spots by name in ascending order" do
     spot_c = Spot.create!(
+      user: users(:one),
       category: categories(:one),
       name: "Zebra Cafe",
       status: "want_to_go"
     )
     spot_a = Spot.create!(
+      user: users(:one),
       category: categories(:one),
       name: "Apple Cafe",
       status: "want_to_go"
@@ -71,6 +74,7 @@ class Api::SpotsControllerTest < ActionDispatch::IntegrationTest
 
   test "sorts spots by created_at in descending order" do
     older_spot = Spot.create!(
+      user: users(:one),
       category: categories(:one),
       name: "Older Cafe",
       status: "want_to_go",
@@ -78,6 +82,7 @@ class Api::SpotsControllerTest < ActionDispatch::IntegrationTest
       updated_at: 2.days.ago
     )
     newer_spot = Spot.create!(
+      user: users(:one),
       category: categories(:one),
       name: "Newer Cafe",
       status: "want_to_go",
@@ -109,6 +114,7 @@ class Api::SpotsControllerTest < ActionDispatch::IntegrationTest
       post "/api/spots",
         params: {
           spot: {
+            user_id: users(:one).id,
             category_id: categories(:one).id,
             name: "Local Sento",
             note: "Open late",
@@ -127,6 +133,7 @@ class Api::SpotsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Local Sento", response_json["name"]
     assert_equal "want_to_go", response_json["status"]
     assert_equal categories(:one).id, response_json["category_id"]
+    assert_equal users(:one).id, response_json["user_id"]
     assert_equal SPOT_RESPONSE_KEYS.sort, response_json.keys.sort
   end
 
@@ -140,6 +147,7 @@ class Api::SpotsControllerTest < ActionDispatch::IntegrationTest
     assert_equal spots(:one).id, response_json["id"]
     assert_equal spots(:one).name, response_json["name"]
     assert_equal spots(:one).status, response_json["status"]
+    assert_equal spots(:one).user_id, response_json["user_id"]
     assert_equal SPOT_RESPONSE_KEYS.sort, response_json.keys.sort
   end
 
@@ -169,6 +177,7 @@ class Api::SpotsControllerTest < ActionDispatch::IntegrationTest
 
     assert_equal "Updated Cafe", response_json["name"]
     assert_equal "visited", response_json["status"]
+    assert_equal spots(:one).user_id, response_json["user_id"]
     assert_equal SPOT_RESPONSE_KEYS.sort, response_json.keys.sort
     assert_equal "Updated Cafe", spots(:one).reload.name
     assert_equal "visited", spots(:one).reload.status
@@ -228,6 +237,7 @@ class Api::SpotsControllerTest < ActionDispatch::IntegrationTest
     response_json = JSON.parse(response.body)
 
     assert_includes response_json["errors"], "Name can't be blank"
+    assert_includes response_json["errors"], "User must exist"
   end
 
   test "returns errors when spot status is unsupported" do
@@ -235,6 +245,7 @@ class Api::SpotsControllerTest < ActionDispatch::IntegrationTest
       post "/api/spots",
         params: {
           spot: {
+            user_id: users(:one).id,
             category_id: categories(:one).id,
             name: "Test Spot",
             status: "archived"
@@ -255,6 +266,7 @@ class Api::SpotsControllerTest < ActionDispatch::IntegrationTest
       post "/api/spots",
         params: {
           spot: {
+            user_id: users(:one).id,
             category_id: -1,
             name: "Ghost Spot",
             status: "want_to_go"
@@ -268,5 +280,46 @@ class Api::SpotsControllerTest < ActionDispatch::IntegrationTest
     response_json = JSON.parse(response.body)
 
     assert_includes response_json["errors"], "Category must exist"
+  end
+
+  test "returns errors when user does not exist" do
+    assert_no_difference("Spot.count") do
+      post "/api/spots",
+        params: {
+          spot: {
+            user_id: -1,
+            category_id: categories(:one).id,
+            name: "Ghost Spot",
+            status: "want_to_go"
+          }
+        },
+        as: :json
+    end
+
+    assert_response :unprocessable_entity
+
+    response_json = JSON.parse(response.body)
+
+    assert_includes response_json["errors"], "User must exist"
+  end
+
+  test "returns errors when user_id is missing" do
+    assert_no_difference("Spot.count") do
+      post "/api/spots",
+        params: {
+          spot: {
+            category_id: categories(:one).id,
+            name: "No Owner Spot",
+            status: "want_to_go"
+          }
+        },
+        as: :json
+    end
+
+    assert_response :unprocessable_entity
+
+    response_json = JSON.parse(response.body)
+
+    assert_includes response_json["errors"], "User must exist"
   end
 end

--- a/backend/test/fixtures/spots.yml
+++ b/backend/test/fixtures/spots.yml
@@ -1,6 +1,7 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
+  user: one
   category: one
   name: Morning Cafe
   note: Quiet place for breakfast
@@ -9,6 +10,7 @@ one:
   visited_on: 2026-04-08
 
 two:
+  user: two
   category: two
   name: Weekend Bookstore
   note: Nice indie bookstore

--- a/backend/test/fixtures/users.yml
+++ b/backend/test/fixtures/users.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: Toki
+
+two:
+  name: Hide

--- a/backend/test/models/spot_test.rb
+++ b/backend/test/models/spot_test.rb
@@ -2,34 +2,41 @@ require "test_helper"
 
 class SpotTest < ActiveSupport::TestCase
   test "is valid with required attributes" do
-    spot = Spot.new(name: "Local Cafe", category: categories(:one), status: :want_to_go)
+    spot = Spot.new(name: "Local Cafe", user: users(:one), category: categories(:one), status: :want_to_go)
 
     assert spot.valid?
   end
 
   test "is invalid without a name" do
-    spot = Spot.new(name: nil, category: categories(:one), status: :want_to_go)
+    spot = Spot.new(name: nil, user: users(:one), category: categories(:one), status: :want_to_go)
 
     assert_not spot.valid?
     assert_includes spot.errors[:name], "can't be blank"
   end
 
   test "is invalid without a category" do
-    spot = Spot.new(name: "Local Cafe", category: nil, status: :want_to_go)
+    spot = Spot.new(name: "Local Cafe", user: users(:one), category: nil, status: :want_to_go)
 
     assert_not spot.valid?
     assert_includes spot.errors[:category], "must exist"
   end
 
+  test "is invalid without a user" do
+    spot = Spot.new(name: "Local Cafe", user: nil, category: categories(:one), status: :want_to_go)
+
+    assert_not spot.valid?
+    assert_includes spot.errors[:user], "must exist"
+  end
+
   test "is invalid with an unsupported status" do
-    spot = Spot.new(name: "Local Cafe", category: categories(:one), status: "archived")
+    spot = Spot.new(name: "Local Cafe", user: users(:one), category: categories(:one), status: "archived")
 
     assert_not spot.valid?
     assert_includes spot.errors[:status], "is not included in the list"
   end
 
   test "allows duplicate names across spots" do
-    spot = Spot.new(name: spots(:one).name, category: categories(:two), status: :visited)
+    spot = Spot.new(name: spots(:one).name, user: users(:one), category: categories(:two), status: :visited)
 
     assert spot.valid?
   end

--- a/backend/test/models/user_test.rb
+++ b/backend/test/models/user_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class UserTest < ActiveSupport::TestCase
+  test "is valid with a name" do
+    user = User.new(name: "New User")
+
+    assert user.valid?
+  end
+
+  test "is invalid without a name" do
+    user = User.new(name: nil)
+
+    assert_not user.valid?
+    assert_includes user.errors[:name], "can't be blank"
+  end
+
+  test "has many spots" do
+    user = users(:one)
+
+    assert_includes user.spots, spots(:one)
+  end
+end


### PR DESCRIPTION
## 概要
Spot に user ownership を導入し、各 Spot が必ず特定の User に属するようにした。

## 変更内容
- `User` モデルと `users` テーブルを追加した
- `spots` テーブルに `user_id` を追加し、既存データ向けの backfill と `null: false` 制約を導入した
- Spot の API で `user_id` を受け取り、response に `user_id` を含めるようにした
- fixture / model test / integration test を更新した

## 変更理由
次のアプリで必要になる ownership 設計を、小さい Rails API のうちに練習するため。
Spot が誰のデータかを表現できるようにし、モデル関連・DB制約・API・テストを通して ownership の基本形を学べるようにした。

## 動作確認
- [x] ローカルで期待どおり動くことを確認した
- [x] 必要なテストを追加または更新した
- [x] 既存機能に影響がないことを確認した

確認した内容:
- `user_id` を指定して Spot を作成できること
- `user_id` がない Spot は保存できないこと
- Spot の response に `user_id` が含まれること
- 既存の Spot 一覧・詳細・更新系テストが通ること

## テスト
- 実行コマンド:
  - `docker compose exec backend bundle exec rails db:migrate`
  - `docker compose exec backend bundle exec rails test`
- 結果:
  - `37 runs, 137 assertions, 0 failures, 0 errors, 0 skips`

## 影響範囲
- frontend:
  - なし
- backend:
  - `User` モデル追加
  - `Spot` の関連と API パラメータ / response を変更
- db:
  - `users` テーブル追加
  - `spots.user_id` 追加
  - foreign key / index / `null: false` 制約追加
  - backfill migration 追加
- infra:
  - なし
- docs:
  - なし
- repository structure:
  - `backend/app/models/user.rb`
  - `backend/test/fixtures/users.yml`
  - `backend/test/models/user_test.rb` を追加

## 関連Issue
- closes #33

## 補足
`spots.user_id` は実務寄りに段階的 migration で導入した。
最初に nullable で追加し、既存データを backfill したあとで `null: false` 制約を付与している。
