### PR TITLE
feat: add simple authentication for spot creation

### DIFF
--- a/backend/app/controllers/api/spots_controller.rb
+++ b/backend/app/controllers/api/spots_controller.rb
@@ -2,13 +2,14 @@ module Api
   class SpotsController < ApplicationController
     before_action :validate_sort_param, only: [ :index ]
     before_action :find_spot, only: [ :show, :update, :destroy ]
+    before_action :authenticate_user!, only: [ :create ]
 
     def index
       render json: spots_for_index.map { |spot| spot_response(spot) }, status: :ok
     end
 
     def create
-      spot = Spot.new(spot_params)
+      spot = Spot.new(spot_params.merge(user: current_user))
 
       if spot.save
         render json: spot_response(spot), status: :created
@@ -66,7 +67,7 @@ module Api
     end
 
     def spot_params
-      params.require(:spot).permit(:category_id, :name, :note, :url, :status, :visited_on, :user_id)
+      params.require(:spot).permit(:category_id, :name, :note, :url, :status, :visited_on)
     end
 
     def spot_response(spot)

--- a/backend/app/controllers/application_controller.rb
+++ b/backend/app/controllers/application_controller.rb
@@ -1,2 +1,16 @@
 class ApplicationController < ActionController::API
+  private
+
+  def current_user
+    return @current_user if defined?(@current_user)
+
+    user_id = request.headers["X-User-Id"]
+    @current_user = user_id.present? ? User.find_by(id: user_id) : nil
+  end
+
+  def authenticate_user!
+    return if current_user
+
+    render json: { errors: [ "Unauthorized" ] }, status: :unauthorized
+  end
 end

--- a/backend/test/controllers/api/spots_controller_test.rb
+++ b/backend/test/controllers/api/spots_controller_test.rb
@@ -114,7 +114,6 @@ class Api::SpotsControllerTest < ActionDispatch::IntegrationTest
       post "/api/spots",
         params: {
           spot: {
-            user_id: users(:one).id,
             category_id: categories(:one).id,
             name: "Local Sento",
             note: "Open late",
@@ -123,6 +122,7 @@ class Api::SpotsControllerTest < ActionDispatch::IntegrationTest
             visited_on: "2026-04-09"
           }
         },
+        headers: auth_headers(users(:one)),
         as: :json
     end
 
@@ -229,6 +229,7 @@ class Api::SpotsControllerTest < ActionDispatch::IntegrationTest
             status: "want_to_go"
           }
         },
+        headers: auth_headers(users(:one)),
         as: :json
     end
 
@@ -237,7 +238,6 @@ class Api::SpotsControllerTest < ActionDispatch::IntegrationTest
     response_json = JSON.parse(response.body)
 
     assert_includes response_json["errors"], "Name can't be blank"
-    assert_includes response_json["errors"], "User must exist"
   end
 
   test "returns errors when spot status is unsupported" do
@@ -245,12 +245,12 @@ class Api::SpotsControllerTest < ActionDispatch::IntegrationTest
       post "/api/spots",
         params: {
           spot: {
-            user_id: users(:one).id,
             category_id: categories(:one).id,
             name: "Test Spot",
             status: "archived"
           }
         },
+        headers: auth_headers(users(:one)),
         as: :json
     end
 
@@ -266,12 +266,12 @@ class Api::SpotsControllerTest < ActionDispatch::IntegrationTest
       post "/api/spots",
         params: {
           spot: {
-            user_id: users(:one).id,
             category_id: -1,
             name: "Ghost Spot",
             status: "want_to_go"
           }
         },
+        headers: auth_headers(users(:one)),
         as: :json
     end
 
@@ -282,28 +282,28 @@ class Api::SpotsControllerTest < ActionDispatch::IntegrationTest
     assert_includes response_json["errors"], "Category must exist"
   end
 
-  test "returns errors when user does not exist" do
+  test "returns unauthorized when user does not exist" do
     assert_no_difference("Spot.count") do
       post "/api/spots",
         params: {
           spot: {
-            user_id: -1,
             category_id: categories(:one).id,
             name: "Ghost Spot",
             status: "want_to_go"
           }
         },
+        headers: { "X-User-Id" => "-1" },
         as: :json
     end
 
-    assert_response :unprocessable_entity
+    assert_response :unauthorized
 
     response_json = JSON.parse(response.body)
 
-    assert_includes response_json["errors"], "User must exist"
+    assert_equal [ "Unauthorized" ], response_json["errors"]
   end
 
-  test "returns errors when user_id is missing" do
+  test "returns unauthorized when user header is missing" do
     assert_no_difference("Spot.count") do
       post "/api/spots",
         params: {
@@ -316,10 +316,39 @@ class Api::SpotsControllerTest < ActionDispatch::IntegrationTest
         as: :json
     end
 
-    assert_response :unprocessable_entity
+    assert_response :unauthorized
 
     response_json = JSON.parse(response.body)
 
-    assert_includes response_json["errors"], "User must exist"
+    assert_equal [ "Unauthorized" ], response_json["errors"]
+  end
+
+  test "uses current_user instead of request user_id" do
+    assert_difference("Spot.count", 1) do
+      post "/api/spots",
+        params: {
+          spot: {
+            user_id: users(:two).id,
+            category_id: categories(:one).id,
+            name: "Header Owned Spot",
+            status: "want_to_go"
+          }
+        },
+        headers: auth_headers(users(:one)),
+        as: :json
+    end
+
+    assert_response :created
+
+    response_json = JSON.parse(response.body)
+
+    assert_equal users(:one).id, response_json["user_id"]
+    assert_equal users(:one).id, Spot.find(response_json["id"]).user_id
+  end
+
+  private
+
+  def auth_headers(user)
+    { "X-User-Id" => user.id.to_s }
   end
 end


### PR DESCRIPTION
## 概要
簡易認証を導入し、`ApplicationController` で `current_user` を扱えるようにした。
あわせて `POST /api/spots` で `current_user` を使って Spot を作成するように変更した。

## 変更内容
- `ApplicationController` に `current_user` と `authenticate_user!` を追加した
- `X-User-Id` ヘッダーを使った簡易認証を導入した
- 未認証時に `401 Unauthorized` を返すようにした
- `POST /api/spots` で request body の `user_id` ではなく `current_user` を使って Spot を保存するようにした
- 認証あり・未認証・不正ユーザー時の integration test を追加 / 更新した

## 変更理由
ownership を導入しても、リクエスト中のユーザーを識別できなければ「誰の Spot を作成しているか」を判定できないため。
本格的な認証基盤の前に、まずは API で `current_user` と `401 Unauthorized` を扱う最小構成を入れるため。

## 動作確認
- [x] ローカルで期待どおり動くことを確認した
- [x] 必要なテストを追加または更新した
- [x] 既存機能に影響がないことを確認した

確認した内容:
- `X-User-Id` ヘッダーありで `POST /api/spots` が成功すること
- `X-User-Id` ヘッダーなしで `POST /api/spots` を実行すると `401 Unauthorized` が返ること
- 存在しない user を指定した場合に `401 Unauthorized` が返ること
- request body に `user_id` を含めても保存時は `current_user` が使われること
- 既存の `update` / `destroy` を含む Rails テストが通ること

## テスト
- 実行コマンド:
  - `docker compose exec backend bundle exec rails test`
  - `docker compose exec backend bundle exec rubocop`
- 結果:
  - `41 runs, 144 assertions, 0 failures, 0 errors, 0 skips`
  - `37 files inspected, no offenses detected`

## 影響範囲
- frontend:
  - なし
- backend:
  - `ApplicationController` に簡易認証処理を追加
  - `POST /api/spots` のユーザー紐付け方法を変更
- db:
  - なし
- infra:
  - なし
- docs:
  - なし
- repository structure:
  - なし

## 関連Issue
- closes #34

## 補足
今回は最小構成の簡易認証として `X-User-Id` ヘッダーを採用した。
`update` / `destroy` の保護や owner ベースの認可は次の Issue で扱う想定。
