### PR TITLE
feat: restrict spot update and destroy to owners

### DIFF
--- a/backend/app/controllers/api/spots_controller.rb
+++ b/backend/app/controllers/api/spots_controller.rb
@@ -2,7 +2,8 @@ module Api
   class SpotsController < ApplicationController
     before_action :validate_sort_param, only: [ :index ]
     before_action :find_spot, only: [ :show, :update, :destroy ]
-    before_action :authenticate_user!, only: [ :create ]
+    before_action :authenticate_user!, only: [ :create, :update, :destroy ]
+    before_action :authorize_spot_owner!, only: [ :update, :destroy ]
 
     def index
       render json: spots_for_index.map { |spot| spot_response(spot) }, status: :ok
@@ -57,6 +58,13 @@ module Api
 
     def find_spot
       @spot = Spot.find_by(id: params[:id])
+    end
+
+    def authorize_spot_owner!
+      return if @spot.nil?
+      return if @spot.user == current_user
+
+      render_forbidden
     end
 
     def validate_sort_param

--- a/backend/app/controllers/application_controller.rb
+++ b/backend/app/controllers/application_controller.rb
@@ -11,6 +11,14 @@ class ApplicationController < ActionController::API
   def authenticate_user!
     return if current_user
 
+    render_unauthorized
+  end
+
+  def render_unauthorized
     render json: { errors: [ "Unauthorized" ] }, status: :unauthorized
+  end
+
+  def render_forbidden
+    render json: { errors: [ "Forbidden" ] }, status: :forbidden
   end
 end

--- a/backend/test/controllers/api/spots_controller_test.rb
+++ b/backend/test/controllers/api/spots_controller_test.rb
@@ -169,6 +169,7 @@ class Api::SpotsControllerTest < ActionDispatch::IntegrationTest
           status: "visited"
         }
       },
+      headers: auth_headers(users(:one)),
       as: :json
 
     assert_response :ok
@@ -183,6 +184,45 @@ class Api::SpotsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "visited", spots(:one).reload.status
   end
 
+  test "returns unauthorized when updating without authentication" do
+    original_name = spots(:one).name
+
+    patch "/api/spots/#{spots(:one).id}",
+      params: {
+        spot: {
+          name: "Updated Cafe"
+        }
+      },
+      as: :json
+
+    assert_response :unauthorized
+
+    response_json = JSON.parse(response.body)
+
+    assert_equal [ "Unauthorized" ], response_json["errors"]
+    assert_equal original_name, spots(:one).reload.name
+  end
+
+  test "returns forbidden when updating another user's spot" do
+    original_name = spots(:two).name
+
+    patch "/api/spots/#{spots(:two).id}",
+      params: {
+        spot: {
+          name: "Hijacked Spot"
+        }
+      },
+      headers: auth_headers(users(:one)),
+      as: :json
+
+    assert_response :forbidden
+
+    response_json = JSON.parse(response.body)
+
+    assert_equal [ "Forbidden" ], response_json["errors"]
+    assert_equal original_name, spots(:two).reload.name
+  end
+
   test "returns not found when updating a non-existent spot" do
     patch "/api/spots/999999",
       params: {
@@ -190,6 +230,7 @@ class Api::SpotsControllerTest < ActionDispatch::IntegrationTest
           name: "Updated Cafe"
         }
       },
+      headers: auth_headers(users(:one)),
       as: :json
 
     assert_response :not_found
@@ -201,15 +242,42 @@ class Api::SpotsControllerTest < ActionDispatch::IntegrationTest
 
   test "destroys a spot" do
     assert_difference("Spot.count", -1) do
-      delete "/api/spots/#{spots(:one).id}"
+      delete "/api/spots/#{spots(:one).id}",
+        headers: auth_headers(users(:one))
     end
 
     assert_response :no_content
   end
 
+  test "returns unauthorized when deleting without authentication" do
+    assert_no_difference("Spot.count") do
+      delete "/api/spots/#{spots(:one).id}"
+    end
+
+    assert_response :unauthorized
+
+    response_json = JSON.parse(response.body)
+
+    assert_equal [ "Unauthorized" ], response_json["errors"]
+  end
+
+  test "returns forbidden when deleting another user's spot" do
+    assert_no_difference("Spot.count") do
+      delete "/api/spots/#{spots(:two).id}",
+        headers: auth_headers(users(:one))
+    end
+
+    assert_response :forbidden
+
+    response_json = JSON.parse(response.body)
+
+    assert_equal [ "Forbidden" ], response_json["errors"]
+  end
+
   test "returns not found when deleting a non-existent spot" do
     assert_no_difference("Spot.count") do
-      delete "/api/spots/999999"
+      delete "/api/spots/999999",
+        headers: auth_headers(users(:one))
     end
 
     assert_response :not_found


### PR DESCRIPTION
## 概要
Spot の更新・削除に owner ベースの認可を導入し、自分の Spot のみ操作できるようにした。

## 変更内容
- `PATCH /api/spots/:id` と `DELETE /api/spots/:id` を認証必須にした
- Spot 更新・削除時に owner チェックを追加した
- 認可違反時に `403 Forbidden` を返すようにした
- `401 Unauthorized` / `403 Forbidden` のレスポンス処理を整理した
- update / destroy の認証・認可に関する integration test を追加 / 更新した

## 変更理由
簡易認証で `current_user` を扱えるようになっても、ownership を見ないままだと他人の Spot を更新・削除できてしまうため。
SpotLog で owner ベースの認可を小さく実装し、認証と認可の違いを学べる状態にするため。

## 動作確認
- [x] ローカルで期待どおり動くことを確認した
- [x] 必要なテストを追加または更新した
- [x] 既存機能に影響がないことを確認した

確認した内容:
- owner 本人は自分の Spot を更新・削除できること
- 未認証で `PATCH /api/spots/:id` と `DELETE /api/spots/:id` を叩くと `401 Unauthorized` が返ること
- 他人の Spot を更新・削除しようとすると `403 Forbidden` が返ること
- 既存の Spot 一覧・詳細・作成系テストを含めて Rails テストが通ること

## テスト
- 実行コマンド:
  - `docker compose exec backend bundle exec rails test test/controllers/api/spots_controller_test.rb`
  - `docker compose exec backend bundle exec rails test`
- 結果:
  - `23 runs, 92 assertions, 0 failures, 0 errors, 0 skips`
  - `45 runs, 158 assertions, 0 failures, 0 errors, 0 skips`

## 影響範囲
- frontend:
  - なし
- backend:
  - `ApplicationController` に `403 Forbidden` 用の共通レスポンスを追加
  - `Api::SpotsController` に owner チェックを追加
  - `PATCH /api/spots/:id`
  - `DELETE /api/spots/:id`
- db:
  - なし
- infra:
  - なし
- docs:
  - なし
- repository structure:
  - なし

## 関連Issue
- closes #35

## 補足
認可違反時のレスポンスは、今回は学習用に意図が分かりやすい `403 Forbidden` を採用した。
一覧・詳細の参照範囲を user 単位で絞るかどうかは、この PR では変更していない。
