### PR TITLE
refactor: unify api error handling

### DIFF
--- a/backend/app/controllers/api/categories_controller.rb
+++ b/backend/app/controllers/api/categories_controller.rb
@@ -13,29 +13,29 @@ module Api
       if category.save
         render json: category_response(category), status: :created
       else
-        render json: { errors: category.errors.full_messages }, status: :unprocessable_entity
+        render_unprocessable_entity(category.errors.full_messages)
       end
     end
 
     def update
       if @category.nil?
-        render json: { errors: [ "Category not found" ] }, status: :not_found
+        render_not_found("Category not found")
       elsif @category.update(category_params)
         render json: category_response(@category), status: :ok
       else
-        render json: { errors: @category.errors.full_messages }, status: :unprocessable_entity
+        render_unprocessable_entity(@category.errors.full_messages)
       end
     end
 
     def destroy
       if @category.nil?
-        render json: { errors: [ "Category not found" ] }, status: :not_found
+        render_not_found("Category not found")
       else
         @category.destroy
         head :no_content
       end
     rescue ActiveRecord::DeleteRestrictionError
-      render json: { errors: [ "Cannot delete category with associated spots" ] }, status: :unprocessable_entity
+      render_unprocessable_entity("Cannot delete category with associated spots")
     end
 
     private

--- a/backend/app/controllers/api/spots_controller.rb
+++ b/backend/app/controllers/api/spots_controller.rb
@@ -15,7 +15,7 @@ module Api
       if spot.save
         render json: spot_response(spot), status: :created
       else
-        render json: { errors: spot.errors.full_messages }, status: :unprocessable_entity
+        render_unprocessable_entity(spot.errors.full_messages)
       end
     end
 
@@ -23,23 +23,23 @@ module Api
       if @spot
         render json: spot_response(@spot), status: :ok
       else
-        render json: { errors: [ "Spot not found" ] }, status: :not_found
+        render_not_found("Spot not found")
       end
     end
 
     def update
       if @spot.nil?
-        render json: { errors: [ "Spot not found" ] }, status: :not_found
+        render_not_found("Spot not found")
       elsif @spot.update(spot_params)
         render json: spot_response(@spot), status: :ok
       else
-        render json: { errors: @spot.errors.full_messages }, status: :unprocessable_entity
+        render_unprocessable_entity(@spot.errors.full_messages)
       end
     end
 
     def destroy
       if @spot.nil?
-        render json: { errors: [ "Spot not found" ] }, status: :not_found
+        render_not_found("Spot not found")
       else
         @spot.destroy
         head :no_content
@@ -71,7 +71,7 @@ module Api
       return unless params[:sort].present?
       return if Spot.sort_order_for(params[:sort])
 
-      render json: { errors: [ "Invalid sort parameter" ] }, status: :bad_request
+      render_bad_request("Invalid sort parameter")
     end
 
     def spot_params

--- a/backend/app/controllers/application_controller.rb
+++ b/backend/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::API
   private
 
+  # Authentication helpers
   def current_user
     return @current_user if defined?(@current_user)
 
@@ -14,11 +15,28 @@ class ApplicationController < ActionController::API
     render_unauthorized
   end
 
+  # Shared JSON error responses
+  def render_bad_request(message)
+    render_error(message, :bad_request)
+  end
+
+  def render_not_found(message)
+    render_error(message, :not_found)
+  end
+
+  def render_unprocessable_entity(errors)
+    render json: { errors: Array(errors) }, status: :unprocessable_entity
+  end
+
   def render_unauthorized
-    render json: { errors: [ "Unauthorized" ] }, status: :unauthorized
+    render_error("Unauthorized", :unauthorized)
   end
 
   def render_forbidden
-    render json: { errors: [ "Forbidden" ] }, status: :forbidden
+    render_error("Forbidden", :forbidden)
+  end
+
+  def render_error(message, status)
+    render json: { errors: [ message ] }, status: status
   end
 end


### PR DESCRIPTION
## 概要
主要な API エラーを `ApplicationController` に共通化し、一貫した JSON 形式で返せるようにした。

## 変更内容
- `ApplicationController` に共通エラーレスポンスメソッドを追加した
- `400 / 401 / 403 / 404 / 422` の返し方を整理した
- `SpotsController` のエラーハンドリングを共通メソッド利用に置き換えた
- `CategoriesController` のエラーハンドリングを共通メソッド利用に置き換えた
- `ApplicationController` に認証ヘルパーと共通エラーレスポンスのブロックコメントを追加した

## 変更理由
現在の API では `404` や `422` を返せているが、controller ごとに個別実装されており、今後 `401` や認可エラーも増えると重複が目立ちやすいため。
エラーレスポンスを共通化し、保守しやすい API にするため。

## 動作確認
- [x] ローカルで期待どおり動くことを確認した
- [x] 必要なテストを追加または更新した
- [x] 既存機能に影響がないことを確認した

確認した内容:
- Spot API の `400 / 401 / 403 / 404 / 422` が一貫した JSON 形式で返ること
- Category API の `404 / 422` が一貫した JSON 形式で返ること
- Spot / Category の既存テストが通ること
- RuboCop が通ること

## テスト
- 実行コマンド:
  - `docker compose exec backend bundle exec rails test`
  - `docker compose exec backend bundle exec rubocop`
- 結果:
  - `45 runs, 158 assertions, 0 failures, 0 errors, 0 skips`
  - `37 files inspected, no offenses detected`

## 影響範囲
- frontend:
  - なし
- backend:
  - `ApplicationController`
  - `Api::SpotsController`
  - `Api::CategoriesController`
- db:
  - なし
- infra:
  - なし
- docs:
  - なし
- repository structure:
  - なし

## 関連Issue
- closes #36

## 補足
今回は既存の `404 / 422 / 400 / 401 / 403` を共通化して、認証・認可導入後もエラー処理の追加先が分かりやすい形に整えた。
`rescue_from` や error code の導入までは行わず、学習用として読みやすさを優先した。
