### PR TITLE
Feature/40 add spot tags relation

### DIFF
--- a/backend/app/models/spot.rb
+++ b/backend/app/models/spot.rb
@@ -11,6 +11,8 @@ class Spot < ApplicationRecord
 
   belongs_to :category
   belongs_to :user
+  has_many :spot_tags, dependent: :destroy
+  has_many :tags, through: :spot_tags
 
   validates :name, presence: true
   validates :status, presence: true

--- a/backend/app/models/spot_tag.rb
+++ b/backend/app/models/spot_tag.rb
@@ -1,0 +1,6 @@
+class SpotTag < ApplicationRecord
+  belongs_to :spot
+  belongs_to :tag
+
+  validates :spot_id, uniqueness: { scope: :tag_id }
+end

--- a/backend/app/models/tag.rb
+++ b/backend/app/models/tag.rb
@@ -1,0 +1,6 @@
+class Tag < ApplicationRecord
+  has_many :spot_tags, dependent: :destroy
+  has_many :spots, through: :spot_tags
+
+  validates :name, presence: true, uniqueness: true
+end

--- a/backend/db/migrate/20260421061748_create_tags.rb
+++ b/backend/db/migrate/20260421061748_create_tags.rb
@@ -1,0 +1,9 @@
+class CreateTags < ActiveRecord::Migration[8.1]
+  def change
+    create_table :tags do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/backend/db/migrate/20260421061748_create_tags.rb
+++ b/backend/db/migrate/20260421061748_create_tags.rb
@@ -5,5 +5,7 @@ class CreateTags < ActiveRecord::Migration[8.1]
 
       t.timestamps
     end
+
+    add_index :tags, :name, unique: true
   end
 end

--- a/backend/db/migrate/20260421061757_create_spot_tags.rb
+++ b/backend/db/migrate/20260421061757_create_spot_tags.rb
@@ -1,0 +1,12 @@
+class CreateSpotTags < ActiveRecord::Migration[8.1]
+  def change
+    create_table :spot_tags do |t|
+      t.references :spot, null: false, foreign_key: true
+      t.references :tag, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :spot_tags, [ :spot_id, :tag_id ], unique: true
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_20_022731) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_21_061757) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -19,6 +19,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_20_022731) do
     t.string "name", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_categories_on_name", unique: true
+  end
+
+  create_table "spot_tags", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "spot_id", null: false
+    t.bigint "tag_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["spot_id", "tag_id"], name: "index_spot_tags_on_spot_id_and_tag_id", unique: true
+    t.index ["spot_id"], name: "index_spot_tags_on_spot_id"
+    t.index ["tag_id"], name: "index_spot_tags_on_tag_id"
   end
 
   create_table "spots", force: :cascade do |t|
@@ -37,12 +47,20 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_20_022731) do
     t.check_constraint "status::text = ANY (ARRAY['want_to_go'::character varying, 'visited'::character varying]::text[])", name: "spots_status_check"
   end
 
+  create_table "tags", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "users", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "name", null: false
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "spot_tags", "spots"
+  add_foreign_key "spot_tags", "tags"
   add_foreign_key "spots", "categories"
   add_foreign_key "spots", "users"
 end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -51,6 +51,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_21_061757) do
     t.datetime "created_at", null: false
     t.string "name", null: false
     t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_tags_on_name", unique: true
   end
 
   create_table "users", force: :cascade do |t|

--- a/backend/test/fixtures/spot_tags.yml
+++ b/backend/test/fixtures/spot_tags.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  spot: one
+  tag: one
+
+two:
+  spot: two
+  tag: two

--- a/backend/test/fixtures/tags.yml
+++ b/backend/test/fixtures/tags.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: cozy
+
+two:
+  name: wifi

--- a/backend/test/models/spot_tag_test.rb
+++ b/backend/test/models/spot_tag_test.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+
+class SpotTagTest < ActiveSupport::TestCase
+  test "is valid with spot and tag" do
+    spot_tag = SpotTag.new(spot: spots(:one), tag: tags(:two))
+
+    assert spot_tag.valid?
+  end
+
+  test "is invalid without a spot" do
+    spot_tag = SpotTag.new(spot: nil, tag: tags(:one))
+
+    assert_not spot_tag.valid?
+    assert_includes spot_tag.errors[:spot], "must exist"
+  end
+
+  test "is invalid without a tag" do
+    spot_tag = SpotTag.new(spot: spots(:one), tag: nil)
+
+    assert_not spot_tag.valid?
+    assert_includes spot_tag.errors[:tag], "must exist"
+  end
+
+  test "is invalid with duplicate spot and tag pair" do
+    spot_tag = SpotTag.new(spot: spots(:one), tag: tags(:one))
+
+    assert_not spot_tag.valid?
+    assert_includes spot_tag.errors[:spot_id], "has already been taken"
+  end
+end

--- a/backend/test/models/spot_test.rb
+++ b/backend/test/models/spot_test.rb
@@ -40,4 +40,10 @@ class SpotTest < ActiveSupport::TestCase
 
     assert spot.valid?
   end
+
+  test "has many tags through spot tags" do
+    spot = spots(:one)
+
+    assert_includes spot.tags, tags(:one)
+  end
 end

--- a/backend/test/models/tag_test.rb
+++ b/backend/test/models/tag_test.rb
@@ -1,0 +1,29 @@
+require "test_helper"
+
+class TagTest < ActiveSupport::TestCase
+  test "is valid with a name" do
+    tag = Tag.new(name: "ramen")
+
+    assert tag.valid?
+  end
+
+  test "is invalid without a name" do
+    tag = Tag.new(name: nil)
+
+    assert_not tag.valid?
+    assert_includes tag.errors[:name], "can't be blank"
+  end
+
+  test "is invalid with a duplicate name" do
+    tag = Tag.new(name: tags(:one).name)
+
+    assert_not tag.valid?
+    assert_includes tag.errors[:name], "has already been taken"
+  end
+
+  test "has many spots through spot tags" do
+    tag = tags(:one)
+
+    assert_includes tag.spots, spots(:one)
+  end
+end


### PR DESCRIPTION
## 概要
Spot と Tag の many-to-many 関連を追加し、`has_many :through` で Spot に複数の Tag を紐づけられるようにしました。

## 変更内容
- `Tag` モデルを追加
- `SpotTag` 中間モデルと `spot_tags` テーブルを追加
- `Spot` / `Tag` に `has_many :through` の関連を追加
- 同じ Spot と Tag の組み合わせが重複しないように unique index と validation を追加
- Tag / SpotTag / Spot の model test と fixtures を追加

## 変更理由
現在の SpotLog は `Category has_many Spots` のシンプルな関連のみだったため、Rails の many-to-many 関連と `has_many :through` を学習するため。
Spot に複数の Tag を付けられるようにすることで、今後の一覧改善や tag 絞り込みの土台にもできるため。

## 動作確認
- [x] ローカルで期待どおり動くことを確認した
- [x] 必要なテストを追加または更新した
- [x] 既存機能に影響がないことを確認した

確認した内容:
- `Spot` から `tags` を取得できること
- `Tag` から `spots` を取得できること
- `SpotTag` で `spot` / `tag` が必須であること
- 同じ Spot と Tag の組み合わせが重複できないこと
- 既存テストがすべて通ること

## テスト
- 実行コマンド:
  - `docker compose exec backend bin/rails test`
  - `docker compose exec backend bin/rubocop`
- 結果:
  - Rails test: `54 runs, 179 assertions, 0 failures, 0 errors, 0 skips`
  - RuboCop: `43 files inspected, no offenses detected`

## 影響範囲
- frontend:
  - なし
- backend:
  - `Spot`, `Tag`, `SpotTag` の model 関連を追加
  - model test を追加
- db:
  - `tags` テーブルを追加
  - `spot_tags` 中間テーブルを追加
  - `spot_tags` に `spot_id` / `tag_id` の unique index を追加
- infra:
  - なし
- docs:
  - なし
- repository structure:
  - なし

## 関連Issue
- closes #40

## 補足
今回は many-to-many 関連の追加までを対象にしています。
Tag による Spot 一覧の絞り込み API は、必要であれば別 Issue で追加する想定です。
