### PR TITLE
refactor: move spot index queries to scopes

### DIFF
--- a/backend/app/controllers/api/spots_controller.rb
+++ b/backend/app/controllers/api/spots_controller.rb
@@ -50,10 +50,10 @@ module Api
 
     def spots_for_index
       spots = Spot.all
-      spots = spots.where(category_id: params[:category_id]) if params[:category_id].present?
+      spots = spots.in_category(params[:category_id]) if params[:category_id].present?
+      spots = spots.sorted_by(params[:sort]) if params[:sort].present?
 
-      sort_order = Spot.sort_order_for(params[:sort])
-      sort_order ? spots.order(sort_order) : spots
+      spots
     end
 
     def find_spot
@@ -69,7 +69,7 @@ module Api
 
     def validate_sort_param
       return unless params[:sort].present?
-      return if Spot.sort_order_for(params[:sort])
+      return if Spot.valid_sort?(params[:sort])
 
       render_bad_request("Invalid sort parameter")
     end

--- a/backend/app/models/spot.rb
+++ b/backend/app/models/spot.rb
@@ -17,7 +17,10 @@ class Spot < ApplicationRecord
   validates :name, presence: true
   validates :status, presence: true
 
-  def self.sort_order_for(sort)
-    SORT_ORDERS[sort]
+  scope :in_category, ->(category_id) { where(category_id: category_id) }
+  scope :sorted_by, ->(sort) { order(SORT_ORDERS.fetch(sort)) }
+
+  def self.valid_sort?(sort)
+    SORT_ORDERS.key?(sort)
   end
 end

--- a/backend/test/models/spot_test.rb
+++ b/backend/test/models/spot_test.rb
@@ -46,4 +46,33 @@ class SpotTest < ActiveSupport::TestCase
 
     assert_includes spot.tags, tags(:one)
   end
+
+  test "in_category returns spots for the category" do
+    assert_equal [ spots(:one) ], Spot.in_category(categories(:one).id)
+  end
+
+  test "sorted_by applies the requested sort order" do
+    spot_c = Spot.create!(
+      user: users(:one),
+      category: categories(:one),
+      name: "Zebra Cafe",
+      status: "want_to_go"
+    )
+    spot_a = Spot.create!(
+      user: users(:one),
+      category: categories(:one),
+      name: "Apple Cafe",
+      status: "want_to_go"
+    )
+
+    assert_equal [ spot_a, spots(:one), spots(:two), spot_c ], Spot.sorted_by("name_asc")
+  end
+
+  test "valid_sort returns true for supported sort values" do
+    assert Spot.valid_sort?("name_asc")
+  end
+
+  test "valid_sort returns false for unsupported sort values" do
+    assert_not Spot.valid_sort?("name_desc")
+  end
 end


### PR DESCRIPTION
## 概要
Spot 一覧 API の検索条件・並び替え条件を `Spot` model の scope に切り出し、controller の query ロジックを読みやすく整理しました。

## 変更内容
- `Spot.in_category` scope を追加
- `Spot.sorted_by` scope を追加
- sort パラメータの判定用に `Spot.valid_sort?` を追加
- `Api::SpotsController#index` の一覧取得ロジックを scope 利用に変更
- 追加した scope / sort 判定の model test を追加

## 変更理由
Spot 一覧 API では今後 filter や sort が増える可能性があるため、controller に query 条件を直接増やし続けると見通しが悪くなる。
検索条件や並び替え条件を model の scope に整理することで、controller の責務を薄くし、一覧取得ロジックを読みやすく保つため。

## 動作確認
- [x] ローカルで期待どおり動くことを確認した
- [x] 必要なテストを追加または更新した
- [x] 既存機能に影響がないことを確認した

確認した内容:
- category_id による Spot 一覧絞り込みがこれまで通り動くこと
- sort による Spot 一覧並び替えがこれまで通り動くこと
- 不正な sort parameter で bad request が返ること
- 追加した model scope が期待通り動くこと
- 既存テストがすべて通ること

## テスト
- 実行コマンド:
  - `docker compose exec backend bin/rails test`
  - `docker compose exec backend bin/rubocop`
- 結果:
  - Rails test: `58 runs, 183 assertions, 0 failures, 0 errors, 0 skips`
  - RuboCop: `43 files inspected, no offenses detected`

## 影響範囲
- frontend:
  - なし
- backend:
  - `Spot` model に一覧取得用 scope を追加
  - `Api::SpotsController#index` の query 組み立てを整理
  - `Spot` model test を追加
- db:
  - なし
- infra:
  - なし
- docs:
  - なし
- repository structure:
  - なし

## 関連Issue
- closes #42

## 補足
今回の変更は既存 API の挙動を変えず、一覧取得ロジックの整理を目的にしています。
pagination や tag filter などの追加機能は含めていません。
