### PR TITLE
refactor: extract spot index query service

### DIFF
--- a/backend/app/controllers/api/spots_controller.rb
+++ b/backend/app/controllers/api/spots_controller.rb
@@ -49,11 +49,10 @@ module Api
     private
 
     def spots_for_index
-      spots = Spot.all
-      spots = spots.in_category(params[:category_id]) if params[:category_id].present?
-      spots = spots.sorted_by(params[:sort]) if params[:sort].present?
-
-      spots
+      Spots::IndexQuery.new(
+        category_id: params[:category_id],
+        sort: params[:sort]
+      ).call
     end
 
     def find_spot

--- a/backend/app/services/spots/index_query.rb
+++ b/backend/app/services/spots/index_query.rb
@@ -1,0 +1,21 @@
+module Spots
+  class IndexQuery
+    def initialize(scope: Spot.all, category_id: nil, sort: nil)
+      @scope = scope
+      @category_id = category_id
+      @sort = sort
+    end
+
+    def call
+      spots = scope
+      spots = spots.in_category(category_id) if category_id.present?
+      spots = spots.sorted_by(sort) if sort.present?
+
+      spots
+    end
+
+    private
+
+    attr_reader :scope, :category_id, :sort
+  end
+end

--- a/backend/test/services/spots/index_query_test.rb
+++ b/backend/test/services/spots/index_query_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+
+module Spots
+  class IndexQueryTest < ActiveSupport::TestCase
+    test "returns all spots without filters" do
+      spots = IndexQuery.new.call
+
+      assert_equal [ spots(:one).id, spots(:two).id ].sort, spots.map(&:id).sort
+    end
+
+    test "filters spots by category" do
+      spots = IndexQuery.new(category_id: categories(:one).id).call
+
+      assert_equal [ spots(:one) ], spots
+    end
+
+    test "sorts spots by requested order" do
+      spot_c = Spot.create!(
+        user: users(:one),
+        category: categories(:one),
+        name: "Zebra Cafe",
+        status: "want_to_go"
+      )
+      spot_a = Spot.create!(
+        user: users(:one),
+        category: categories(:one),
+        name: "Apple Cafe",
+        status: "want_to_go"
+      )
+
+      spots = IndexQuery.new(sort: "name_asc").call
+
+      assert_equal [ spot_a, spots(:one), spots(:two), spot_c ], spots
+    end
+
+    test "combines category filter and sort" do
+      spot_a = Spot.create!(
+        user: users(:one),
+        category: categories(:one),
+        name: "Apple Cafe",
+        status: "want_to_go"
+      )
+
+      spots = IndexQuery.new(category_id: categories(:one).id, sort: "name_asc").call
+
+      assert_equal [ spot_a, spots(:one) ], spots
+    end
+  end
+end


### PR DESCRIPTION
## 概要
Spot 一覧取得処理を `Spots::IndexQuery` service に切り出し、Service Object の基本形を導入しました。

## 変更内容
- `Spots::IndexQuery` service class を追加
- `Api::SpotsController#index` の一覧取得処理を service 呼び出しに変更
- `Spots::IndexQuery` の service test を追加
- category filter / sort / filter と sort の組み合わせを service test で確認

## 変更理由
Service Object の基本形に触れるため、既存処理のうち1つだけを対象に責務分離を試したかったため。
今回は過度な抽象化を避けるため、対象を Spot 一覧取得 query の組み立て処理に限定した。

## 動作確認
- [x] ローカルで期待どおり動くことを確認した
- [x] 必要なテストを追加または更新した
- [x] 既存機能に影響がないことを確認した

確認した内容:
- filter なしで Spot 一覧が取得できること
- category_id で Spot 一覧を絞り込めること
- sort 指定で Spot 一覧を並び替えられること
- category filter と sort を組み合わせても期待通りに動くこと
- controller 経由の既存 API テストが通ること

## テスト
- 実行コマンド:
  - `docker compose exec backend bin/rails test`
  - `docker compose exec backend bin/rubocop`
- 結果:
  - Rails test: `62 runs, 187 assertions, 0 failures, 0 errors, 0 skips`
  - RuboCop: `45 files inspected, no offenses detected`

## 影響範囲
- frontend:
  - なし
- backend:
  - Spot 一覧取得処理を service object に切り出し
  - service test を追加
- db:
  - なし
- infra:
  - なし
- docs:
  - なし
- repository structure:
  - `backend/app/services/` を追加
  - `backend/test/services/` を追加

## 関連Issue
- closes #43

## 補足
今回は Service Object の学習目的として、1つの処理だけを小さく切り出しています。
現在の規模では必須の抽象化ではありませんが、controller から処理を切り出す基本形を確認するための実装です。
