### PR TITLE
Feature/55 display spots api in nextjs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,4 @@ DB_NAME=my_app_development
 DB_NAME_TEST=my_app_test
 RAILS_ENV=development
 FRONTEND_ORIGIN=http://localhost:3001
+NEXT_PUBLIC_API_BASE_URL=http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -126,6 +126,14 @@ docker compose exec frontend npm run lint
 docker compose exec frontend npm run build
 ```
 
+Rails API との疎通を確認したいとき:
+
+```bash
+curl http://localhost:3000/api/spots
+```
+
+frontend 画面に `Loaded spots: N` が表示されれば、Next.js から Rails API を取得できています。
+
 ---
 
 # CI

--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -33,7 +33,7 @@ gem "thruster", require: false
 gem "image_processing", "~> 1.2"
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin Ajax possible
-# gem "rack-cors"
+gem "rack-cors"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -214,6 +214,9 @@ GEM
     raabro (1.4.0)
     racc (1.8.1)
     rack (3.2.6)
+    rack-cors (3.0.0)
+      logger
+      rack (>= 3.0.14)
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -358,6 +361,7 @@ DEPENDENCIES
   kamal
   pg (~> 1.1)
   puma (>= 5.0)
+  rack-cors
   rails (~> 8.1.2)
   rubocop-rails-omakase
   solid_cable

--- a/backend/config/initializers/cors.rb
+++ b/backend/config/initializers/cors.rb
@@ -1,16 +1,9 @@
-# Be sure to restart your server when you modify this file.
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins ENV.fetch("FRONTEND_ORIGIN", "http://localhost:3001")
 
-# Avoid CORS issues when API is called from the frontend app.
-# Handle Cross-Origin Resource Sharing (CORS) in order to accept cross-origin Ajax requests.
-
-# Read more: https://github.com/cyu/rack-cors
-
-# Rails.application.config.middleware.insert_before 0, Rack::Cors do
-#   allow do
-#     origins "example.com"
-#
-#     resource "*",
-#       headers: :any,
-#       methods: [:get, :post, :put, :patch, :delete, :options, :head]
-#   end
-# end
+    resource "*",
+      headers: :any,
+      methods: [ :get, :post, :put, :patch, :delete, :options, :head ]
+  end
+end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,7 @@ services:
       context: ./frontend
     environment:
       WATCHPACK_POLLING: "true"
+      NEXT_PUBLIC_API_BASE_URL: ${NEXT_PUBLIC_API_BASE_URL}
     volumes:
       - ./frontend:/frontend
       - frontend-node-modules:/frontend/node_modules

--- a/frontend/src/app/components/SpotsApiCheck.tsx
+++ b/frontend/src/app/components/SpotsApiCheck.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import type { Spot } from "@/types/spot";
+
+type FetchState =
+  | { status: "loading" }
+  | { status: "success"; spots: Spot[] }
+  | { status: "error"; message: string };
+
+export function SpotsApiCheck() {
+  const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
+  const [state, setState] = useState<FetchState>({ status: "loading" });
+
+  useEffect(() => {
+    if (!apiBaseUrl) return;
+
+    let ignore = false;
+
+    const fetchSpots = async () => {
+      try {
+        const response = await fetch(`${apiBaseUrl}/api/spots`);
+
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+
+        const spots: Spot[] = await response.json();
+
+        if (!ignore) {
+          setState({ status: "success", spots });
+        }
+      } catch (error) {
+        if (!ignore) {
+          setState({
+            status: "error",
+            message:
+              error instanceof Error ? error.message : "Unknown error occurred",
+          });
+        }
+      }
+    };
+
+    fetchSpots();
+
+    return () => {
+      ignore = true;
+    };
+  }, [apiBaseUrl]);
+
+  if (!apiBaseUrl) {
+    return <p>API error: NEXT_PUBLIC_API_BASE_URL is not set</p>;
+  }
+
+  if (state.status === "loading") {
+    return <p>Loading spots...</p>;
+  }
+
+  if (state.status === "error") {
+    return <p>API error: {state.message}</p>;
+  }
+
+  return (
+    <section>
+      <h2>Spots API check</h2>
+      <p>Loaded spots: {state.spots.length}</p>
+
+      {state.spots.length > 0 && (
+        <ul>
+          {state.spots.map((spot) => (
+            <li key={spot.id}>
+              {spot.name} ({spot.status})
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,65 +1,10 @@
-import Image from "next/image";
+import { SpotsApiCheck } from "./components/SpotsApiCheck";
 
 export default function Home() {
   return (
-    <div className="flex flex-col flex-1 items-center justify-center bg-zinc-50 font-sans dark:bg-black">
-      <main className="flex flex-1 w-full max-w-3xl flex-col items-center justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={100}
-          height={20}
-          priority
-        />
-        <div className="flex flex-col items-center gap-6 text-center sm:items-start sm:text-left">
-          <h1 className="max-w-xs text-3xl font-semibold leading-10 tracking-tight text-black dark:text-zinc-50">
-            To get started, edit the page.tsx file.
-          </h1>
-          <p className="max-w-md text-lg leading-8 text-zinc-600 dark:text-zinc-400">
-            Looking for a starting point or more instructions? Head over to{" "}
-            <a
-              href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Templates
-            </a>{" "}
-            or the{" "}
-            <a
-              href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Learning
-            </a>{" "}
-            center.
-          </p>
-        </div>
-        <div className="flex flex-col gap-4 text-base font-medium sm:flex-row">
-          <a
-            className="flex h-12 w-full items-center justify-center gap-2 rounded-full bg-foreground px-5 text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc] md:w-[158px]"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={16}
-              height={16}
-            />
-            Deploy Now
-          </a>
-          <a
-            className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/[.08] px-5 transition-colors hover:border-transparent hover:bg-black/[.04] dark:border-white/[.145] dark:hover:bg-[#1a1a1a] md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Documentation
-          </a>
-        </div>
-      </main>
-    </div>
+    <main>
+      <h1>SpotLog Frontend</h1>
+      <SpotsApiCheck />
+    </main>
   );
 }

--- a/frontend/src/types/spot.ts
+++ b/frontend/src/types/spot.ts
@@ -1,0 +1,12 @@
+export type Spot = {
+  id: number;
+  category_id: number;
+  user_id: number;
+  name: string;
+  note: string | null;
+  url: string | null;
+  status: "want_to_go" | "visited";
+  visited_on: string | null;
+  created_at: string;
+  updated_at: string;
+};


### PR DESCRIPTION
## 概要
Next.js から Rails の既存 Spots API を取得し、frontend 画面に取得結果を表示できるようにしました。

## 変更内容
- frontend 用の API base URL を `.env.example` / `docker-compose.yml` に追加
- Rails API を frontend から呼び出せるように `rack-cors` を有効化し、CORS 設定を追加
- Next.js のトップページで `GET /api/spots` を fetch し、loading / error / success 状態を表示
- `Spot` 型を `frontend/src/types/spot.ts` に切り出し
- README に Spots API 疎通確認手順を追記

## 変更理由
Issue 44 で Next.js の Docker 環境を追加したため、次の段階として Rails API と frontend が実際に連携できることを確認する必要があったためです。

この PR では本格的な Spots 一覧 UI や CRUD 実装には進まず、`GET /api/spots` の最小疎通確認に範囲を絞っています。

## 動作確認
- [x] ローカルで期待どおり動くことを確認した
- [x] 必要なテストを追加または更新した
- [x] 既存機能に影響がないことを確認した

確認した内容:
- `http://localhost:3001` にアクセスし、`Loaded spots: 4` と spot 名・status が表示されることを確認
- Rails API `GET /api/spots` の取得結果が frontend に表示されることを確認
- spots が取得できる場合に success 状態が表示されることを確認

## テスト
- 実行コマンド:
  - `docker compose exec frontend npm run lint`
  - `docker compose exec frontend npm run build`
  - `docker compose exec backend bundle exec rails test`
  - `docker compose exec backend bundle exec rubocop`
- 結果:
  - frontend lint 成功
  - frontend build 成功
  - backend test 成功: `62 runs, 187 assertions, 0 failures, 0 errors, 0 skips`
  - backend rubocop 成功: `45 files inspected, no offenses detected`

## 影響範囲
- frontend: トップページに Spots API 疎通確認表示を追加
- backend: CORS 設定を追加
- db: 変更なし
- infra: frontend に `NEXT_PUBLIC_API_BASE_URL` を渡す設定を追加
- docs: README に API 疎通確認手順を追記
- repository structure: `frontend/src/app/components/` と `frontend/src/types/` を追加

## 関連Issue
- closes #55

## 補足
この PR では、Spots 一覧画面の本格的な UI 実装、作成・更新・削除フォーム、API client の本格設計、frontend の自動テスト導入は行っていません。

frontend の挙動確認テストは、次以降の Issue で Vitest / React Testing Library または Playwright の導入とあわせて検討する想定です。
