### PR TITLE
Feature/60 add spot create form

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,4 @@ DB_NAME_TEST=my_app_test
 RAILS_ENV=development
 FRONTEND_ORIGIN=http://localhost:3001
 NEXT_PUBLIC_API_BASE_URL=http://localhost:3000
+NEXT_PUBLIC_DEMO_USER_ID=1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,7 @@ services:
     environment:
       WATCHPACK_POLLING: "true"
       NEXT_PUBLIC_API_BASE_URL: ${NEXT_PUBLIC_API_BASE_URL}
+      NEXT_PUBLIC_DEMO_USER_ID: ${NEXT_PUBLIC_DEMO_USER_ID:-1}
     volumes:
       - ./frontend:/frontend
       - frontend-node-modules:/frontend/node_modules

--- a/frontend/src/app/components/SpotCreateForm.tsx
+++ b/frontend/src/app/components/SpotCreateForm.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import { useState } from "react";
+
+import type { Spot, SpotFormValues } from "@/types/spot";
+
+type SpotCreateFormProps = {
+  onCreated: (spot: Spot) => void;
+};
+
+type CreateSpotResponse = Spot | { errors?: string[] };
+
+const initialValues: SpotFormValues = {
+  category_id: "1",
+  name: "",
+  note: "",
+  url: "",
+  status: "want_to_go",
+};
+
+export function SpotCreateForm({ onCreated }: SpotCreateFormProps) {
+  const [values, setValues] = useState<SpotFormValues>(initialValues);
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const updateValue = (field: keyof SpotFormValues, value: string) => {
+    setValues((currentValues) => ({
+      ...currentValues,
+      [field]: value,
+    }));
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+    if (!apiBaseUrl) {
+      setError("NEXT_PUBLIC_API_BASE_URL is not set");
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      const response = await fetch(`${apiBaseUrl}/api/spots`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-User-Id": "1",
+        },
+        body: JSON.stringify({
+          spot: {
+            category_id: Number(values.category_id),
+            name: values.name,
+            note: values.note,
+            url: values.url,
+            status: values.status,
+          },
+        }),
+      });
+
+      const data = (await response.json()) as CreateSpotResponse;
+
+      if (!response.ok) {
+        throw new Error(
+          "errors" in data && Array.isArray(data.errors)
+            ? data.errors.join(", ")
+            : `HTTP ${response.status}`,
+        );
+      }
+
+      onCreated(data as Spot);
+      setValues(initialValues);
+    } catch (submitError) {
+      setError(
+        submitError instanceof Error
+          ? submitError.message
+          : "Unknown error occurred",
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="rounded-lg border border-zinc-200 bg-white p-5 shadow-sm"
+    >
+      <div className="space-y-5">
+        <div className="space-y-1">
+          <h2 className="text-xl font-semibold text-zinc-900">
+            スポットを追加
+          </h2>
+          <p className="text-sm text-zinc-600">
+            行きたい場所や訪問済みの場所を保存します。
+          </p>
+        </div>
+
+        <div className="grid gap-4">
+          <div>
+            <label
+              htmlFor="spot-name"
+              className="block text-sm font-medium text-zinc-700"
+            >
+              名前
+            </label>
+            <input
+              id="spot-name"
+              value={values.name}
+              onChange={(event) => updateValue("name", event.target.value)}
+              className="mt-1 w-full rounded-md border border-zinc-300 px-3 py-2 text-sm text-zinc-900 shadow-sm focus:border-zinc-500 focus:outline-none focus:ring-2 focus:ring-zinc-200"
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor="spot-note"
+              className="block text-sm font-medium text-zinc-700"
+            >
+              メモ
+            </label>
+            <textarea
+              id="spot-note"
+              value={values.note}
+              onChange={(event) => updateValue("note", event.target.value)}
+              className="mt-1 min-h-20 w-full rounded-md border border-zinc-300 px-3 py-2 text-sm text-zinc-900 shadow-sm focus:border-zinc-500 focus:outline-none focus:ring-2 focus:ring-zinc-200"
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor="spot-url"
+              className="block text-sm font-medium text-zinc-700"
+            >
+              URL
+            </label>
+            <input
+              id="spot-url"
+              type="url"
+              value={values.url}
+              onChange={(event) => updateValue("url", event.target.value)}
+              className="mt-1 w-full rounded-md border border-zinc-300 px-3 py-2 text-sm text-zinc-900 shadow-sm focus:border-zinc-500 focus:outline-none focus:ring-2 focus:ring-zinc-200"
+            />
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div>
+              <label
+                htmlFor="spot-status"
+                className="block text-sm font-medium text-zinc-700"
+              >
+                ステータス
+              </label>
+              <select
+                id="spot-status"
+                value={values.status}
+                onChange={(event) => updateValue("status", event.target.value)}
+                className="mt-1 w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 shadow-sm focus:border-zinc-500 focus:outline-none focus:ring-2 focus:ring-zinc-200"
+              >
+                <option value="want_to_go">行きたい</option>
+                <option value="visited">訪問済み</option>
+              </select>
+            </div>
+
+            <div>
+              <label
+                htmlFor="spot-category-id"
+                className="block text-sm font-medium text-zinc-700"
+              >
+                Category ID
+              </label>
+              <input
+                id="spot-category-id"
+                type="number"
+                min="1"
+                value={values.category_id}
+                onChange={(event) =>
+                  updateValue("category_id", event.target.value)
+                }
+                className="mt-1 w-full rounded-md border border-zinc-300 px-3 py-2 text-sm text-zinc-900 shadow-sm focus:border-zinc-500 focus:outline-none focus:ring-2 focus:ring-zinc-200"
+              />
+            </div>
+          </div>
+        </div>
+
+        {error && (
+          <p className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">
+            {error}
+          </p>
+        )}
+
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white shadow-sm disabled:cursor-not-allowed disabled:bg-zinc-400"
+        >
+          {isSubmitting ? "保存中..." : "保存する"}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/app/components/SpotCreateForm.tsx
+++ b/frontend/src/app/components/SpotCreateForm.tsx
@@ -13,7 +13,7 @@ type SpotCreateFormProps = {
 type CreateSpotResponse = Spot | { errors?: string[] };
 
 const initialValues: SpotFormValues = {
-  category_id: "1",
+  category_id: "",
   name: "",
   note: "",
   url: "",
@@ -27,6 +27,7 @@ export function SpotCreateForm({ categories, onCreated }: SpotCreateFormProps) {
   }));
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const hasCategories = categories.length > 0;
 
   const updateValue = (field: keyof SpotFormValues, value: string) => {
     setValues((currentValues) => ({
@@ -39,6 +40,11 @@ export function SpotCreateForm({ categories, onCreated }: SpotCreateFormProps) {
     event.preventDefault();
 
     const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+    if (!hasCategories || !values.category_id) {
+      setError("カテゴリーを選択してください");
+      return;
+    }
 
     if (!apiBaseUrl) {
       setError("NEXT_PUBLIC_API_BASE_URL is not set");
@@ -182,7 +188,7 @@ export function SpotCreateForm({ categories, onCreated }: SpotCreateFormProps) {
               </label>
               <select
                 id="spot-category-id"
-                disabled={categories.length === 0}
+                disabled={!hasCategories}
                 value={values.category_id}
                 onChange={(event) =>
                   updateValue("category_id", event.target.value)
@@ -211,7 +217,7 @@ export function SpotCreateForm({ categories, onCreated }: SpotCreateFormProps) {
 
         <button
           type="submit"
-          disabled={isSubmitting}
+          disabled={isSubmitting || !hasCategories}
           className="rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white shadow-sm disabled:cursor-not-allowed disabled:bg-zinc-400"
         >
           {isSubmitting ? "保存中..." : "保存する"}

--- a/frontend/src/app/components/SpotCreateForm.tsx
+++ b/frontend/src/app/components/SpotCreateForm.tsx
@@ -7,6 +7,7 @@ import type { Spot, SpotFormValues } from "@/types/spot";
 
 type SpotCreateFormProps = {
   categories: Category[];
+  categoryError?: string;
   onCreated: (spot: Spot) => void;
 };
 
@@ -20,7 +21,11 @@ const initialValues: SpotFormValues = {
   status: "want_to_go",
 };
 
-export function SpotCreateForm({ categories, onCreated }: SpotCreateFormProps) {
+export function SpotCreateForm({
+  categories,
+  categoryError,
+  onCreated,
+}: SpotCreateFormProps) {
   const [values, setValues] = useState<SpotFormValues>(() => ({
     ...initialValues,
     category_id: categories[0]?.id.toString() ?? initialValues.category_id,
@@ -40,6 +45,12 @@ export function SpotCreateForm({ categories, onCreated }: SpotCreateFormProps) {
     event.preventDefault();
 
     const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
+    const demoUserId = process.env.NEXT_PUBLIC_DEMO_USER_ID;
+
+    if (categoryError) {
+      setError("カテゴリーを取得できないため、スポットを作成できません");
+      return;
+    }
 
     if (!hasCategories || !values.category_id) {
       setError("カテゴリーを選択してください");
@@ -51,6 +62,11 @@ export function SpotCreateForm({ categories, onCreated }: SpotCreateFormProps) {
       return;
     }
 
+    if (!demoUserId) {
+      setError("NEXT_PUBLIC_DEMO_USER_ID is not set");
+      return;
+    }
+
     setIsSubmitting(true);
     setError(null);
 
@@ -59,7 +75,7 @@ export function SpotCreateForm({ categories, onCreated }: SpotCreateFormProps) {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "X-User-Id": "1",
+          "X-User-Id": demoUserId,
         },
         body: JSON.stringify({
           spot: {
@@ -188,14 +204,16 @@ export function SpotCreateForm({ categories, onCreated }: SpotCreateFormProps) {
               </label>
               <select
                 id="spot-category-id"
-                disabled={!hasCategories}
+                disabled={!hasCategories || Boolean(categoryError)}
                 value={values.category_id}
                 onChange={(event) =>
                   updateValue("category_id", event.target.value)
                 }
                 className="mt-1 w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 shadow-sm focus:border-zinc-500 focus:outline-none focus:ring-2 focus:ring-zinc-200 disabled:cursor-not-allowed disabled:bg-zinc-100"
               >
-                {categories.length === 0 ? (
+                {categoryError ? (
+                  <option value="">カテゴリーを取得できません</option>
+                ) : categories.length === 0 ? (
                   <option value="">カテゴリーがありません</option>
                 ) : (
                   categories.map((category) => (
@@ -205,6 +223,11 @@ export function SpotCreateForm({ categories, onCreated }: SpotCreateFormProps) {
                   ))
                 )}
               </select>
+              {categoryError && (
+                <p className="mt-1 text-sm text-red-700">
+                  カテゴリーの取得に失敗しました: {categoryError}
+                </p>
+              )}
             </div>
           </div>
         </div>
@@ -217,7 +240,7 @@ export function SpotCreateForm({ categories, onCreated }: SpotCreateFormProps) {
 
         <button
           type="submit"
-          disabled={isSubmitting || !hasCategories}
+          disabled={isSubmitting || !hasCategories || Boolean(categoryError)}
           className="rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white shadow-sm disabled:cursor-not-allowed disabled:bg-zinc-400"
         >
           {isSubmitting ? "保存中..." : "保存する"}

--- a/frontend/src/app/components/SpotCreateForm.tsx
+++ b/frontend/src/app/components/SpotCreateForm.tsx
@@ -2,9 +2,11 @@
 
 import { useState } from "react";
 
+import type { Category } from "@/types/category";
 import type { Spot, SpotFormValues } from "@/types/spot";
 
 type SpotCreateFormProps = {
+  categories: Category[];
   onCreated: (spot: Spot) => void;
 };
 
@@ -18,8 +20,11 @@ const initialValues: SpotFormValues = {
   status: "want_to_go",
 };
 
-export function SpotCreateForm({ onCreated }: SpotCreateFormProps) {
-  const [values, setValues] = useState<SpotFormValues>(initialValues);
+export function SpotCreateForm({ categories, onCreated }: SpotCreateFormProps) {
+  const [values, setValues] = useState<SpotFormValues>(() => ({
+    ...initialValues,
+    category_id: categories[0]?.id.toString() ?? initialValues.category_id,
+  }));
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -72,7 +77,10 @@ export function SpotCreateForm({ onCreated }: SpotCreateFormProps) {
       }
 
       onCreated(data as Spot);
-      setValues(initialValues);
+      setValues({
+        ...initialValues,
+        category_id: categories[0]?.id.toString() ?? initialValues.category_id,
+      });
     } catch (submitError) {
       setError(
         submitError instanceof Error
@@ -170,18 +178,27 @@ export function SpotCreateForm({ onCreated }: SpotCreateFormProps) {
                 htmlFor="spot-category-id"
                 className="block text-sm font-medium text-zinc-700"
               >
-                Category ID
+                カテゴリー
               </label>
-              <input
+              <select
                 id="spot-category-id"
-                type="number"
-                min="1"
+                disabled={categories.length === 0}
                 value={values.category_id}
                 onChange={(event) =>
                   updateValue("category_id", event.target.value)
                 }
-                className="mt-1 w-full rounded-md border border-zinc-300 px-3 py-2 text-sm text-zinc-900 shadow-sm focus:border-zinc-500 focus:outline-none focus:ring-2 focus:ring-zinc-200"
-              />
+                className="mt-1 w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 shadow-sm focus:border-zinc-500 focus:outline-none focus:ring-2 focus:ring-zinc-200 disabled:cursor-not-allowed disabled:bg-zinc-100"
+              >
+                {categories.length === 0 ? (
+                  <option value="">カテゴリーがありません</option>
+                ) : (
+                  categories.map((category) => (
+                    <option key={category.id} value={category.id}>
+                      {category.name}
+                    </option>
+                  ))
+                )}
+              </select>
             </div>
           </div>
         </div>

--- a/frontend/src/app/components/SpotsList.tsx
+++ b/frontend/src/app/components/SpotsList.tsx
@@ -41,6 +41,21 @@ function findCategoryName(categories: Category[], categoryId: number) {
   return categories.find((category) => category.id === categoryId)?.name;
 }
 
+async function fetchCategories(apiBaseUrl: string) {
+  try {
+    const response = await fetch(`${apiBaseUrl}/api/categories`);
+
+    if (!response.ok) {
+      return [];
+    }
+
+    const categories: Category[] = await response.json();
+    return categories;
+  } catch {
+    return [];
+  }
+}
+
 function SpotsListMessage({ tone = "default", children }: SpotsListMessageProps) {
   const isError = tone === "error";
 
@@ -140,21 +155,16 @@ export function SpotsList() {
 
     const fetchSpots = async () => {
       try {
-        const [spotsResponse, categoriesResponse] = await Promise.all([
+        const [spotsResponse, categories] = await Promise.all([
           fetch(`${apiBaseUrl}/api/spots`),
-          fetch(`${apiBaseUrl}/api/categories`),
+          fetchCategories(apiBaseUrl),
         ]);
 
         if (!spotsResponse.ok) {
           throw new Error(`Spots HTTP ${spotsResponse.status}`);
         }
 
-        if (!categoriesResponse.ok) {
-          throw new Error(`Categories HTTP ${categoriesResponse.status}`);
-        }
-
         const spots: Spot[] = await spotsResponse.json();
-        const categories: Category[] = await categoriesResponse.json();
 
         if (!ignore) {
           setState({ status: "success", categories, spots });

--- a/frontend/src/app/components/SpotsList.tsx
+++ b/frontend/src/app/components/SpotsList.tsx
@@ -9,7 +9,11 @@ import { SpotCreateForm } from "./SpotCreateForm";
 
 type FetchState =
   | { status: "loading" }
-  | { status: "success"; categories: Category[]; spots: Spot[] }
+  | { status: "success"; categoriesState: CategoriesState; spots: Spot[] }
+  | { status: "error"; message: string };
+
+type CategoriesState =
+  | { status: "success"; categories: Category[] }
   | { status: "error"; message: string };
 
 type SpotsListMessageProps = {
@@ -23,7 +27,7 @@ type SpotListItemProps = {
 };
 
 type SpotsListContentProps = {
-  categories: Category[];
+  categoriesState: CategoriesState;
   spots: Spot[];
   onSpotCreated: (spot: Spot) => void;
 };
@@ -54,18 +58,24 @@ function safeHttpUrl(url: string | null) {
   }
 }
 
-async function fetchCategories(apiBaseUrl: string) {
+async function fetchCategories(apiBaseUrl: string): Promise<CategoriesState> {
   try {
     const response = await fetch(`${apiBaseUrl}/api/categories`);
 
     if (!response.ok) {
-      return [];
+      return {
+        status: "error",
+        message: `Categories HTTP ${response.status}`,
+      };
     }
 
     const categories: Category[] = await response.json();
-    return categories;
-  } catch {
-    return [];
+    return { status: "success", categories };
+  } catch (error) {
+    return {
+      status: "error",
+      message: error instanceof Error ? error.message : "Unknown error occurred",
+    };
   }
 }
 
@@ -130,13 +140,22 @@ function SpotListItem({ categories, spot }: SpotListItemProps) {
 }
 
 function SpotsListContent({
-  categories,
+  categoriesState,
   spots,
   onSpotCreated,
 }: SpotsListContentProps) {
+  const categories =
+    categoriesState.status === "success" ? categoriesState.categories : [];
+
   return (
     <section className="space-y-6">
-      <SpotCreateForm categories={categories} onCreated={onSpotCreated} />
+      <SpotCreateForm
+        categories={categories}
+        categoryError={
+          categoriesState.status === "error" ? categoriesState.message : undefined
+        }
+        onCreated={onSpotCreated}
+      />
 
       <div className="space-y-1">
         <h2 className="text-xl font-semibold text-zinc-900">保存したスポット</h2>
@@ -169,7 +188,7 @@ export function SpotsList() {
 
     const fetchSpots = async () => {
       try {
-        const [spotsResponse, categories] = await Promise.all([
+        const [spotsResponse, categoriesState] = await Promise.all([
           fetch(`${apiBaseUrl}/api/spots`),
           fetchCategories(apiBaseUrl),
         ]);
@@ -181,7 +200,7 @@ export function SpotsList() {
         const spots: Spot[] = await spotsResponse.json();
 
         if (!ignore) {
-          setState({ status: "success", categories, spots });
+          setState({ status: "success", categoriesState, spots });
         }
       } catch (error) {
         if (!ignore) {
@@ -209,7 +228,7 @@ export function SpotsList() {
 
       return {
         status: "success",
-        categories: currentState.categories,
+        categoriesState: currentState.categoriesState,
         spots: [spot, ...currentState.spots],
       };
     });
@@ -237,7 +256,7 @@ export function SpotsList() {
 
   return (
     <SpotsListContent
-      categories={state.categories}
+      categoriesState={state.categoriesState}
       spots={state.spots}
       onSpotCreated={handleSpotCreated}
     />

--- a/frontend/src/app/components/SpotsList.tsx
+++ b/frontend/src/app/components/SpotsList.tsx
@@ -4,6 +4,8 @@ import { useEffect, useState } from "react";
 
 import type { Spot } from "@/types/spot";
 
+import { SpotCreateForm } from "./SpotCreateForm";
+
 type FetchState =
   | { status: "loading" }
   | { status: "success"; spots: Spot[] }
@@ -16,6 +18,11 @@ type SpotsListMessageProps = {
 
 type SpotListItemProps = {
   spot: Spot;
+};
+
+type SpotsListContentProps = {
+  spots: Spot[];
+  onSpotCreated: (spot: Spot) => void;
 };
 
 function formatSpotStatus(status: Spot["status"]) {
@@ -68,19 +75,27 @@ function SpotListItem({ spot }: SpotListItemProps) {
   );
 }
 
-function SpotsListContent({ spots }: { spots: Spot[] }) {
+function SpotsListContent({ spots, onSpotCreated }: SpotsListContentProps) {
   return (
-    <section className="space-y-4">
+    <section className="space-y-6">
+      <SpotCreateForm onCreated={onSpotCreated} />
+
       <div className="space-y-1">
         <h2 className="text-xl font-semibold text-zinc-900">保存したスポット</h2>
         <p className="text-sm text-zinc-600">{spots.length} spots</p>
       </div>
 
-      <ul className="space-y-3">
-        {spots.map((spot) => (
-          <SpotListItem key={spot.id} spot={spot} />
-        ))}
-      </ul>
+      {spots.length === 0 ? (
+        <div className="rounded-lg border border-zinc-200 bg-white p-5 text-sm text-zinc-600 shadow-sm">
+          行きたい場所をまだ保存していません。
+        </div>
+      ) : (
+        <ul className="space-y-3">
+          {spots.map((spot) => (
+            <SpotListItem key={spot.id} spot={spot} />
+          ))}
+        </ul>
+      )}
     </section>
   );
 }
@@ -125,6 +140,19 @@ export function SpotsList() {
     };
   }, [apiBaseUrl]);
 
+  const handleSpotCreated = (spot: Spot) => {
+    setState((currentState) => {
+      if (currentState.status !== "success") {
+        return currentState;
+      }
+
+      return {
+        status: "success",
+        spots: [spot, ...currentState.spots],
+      };
+    });
+  };
+
   if (!apiBaseUrl) {
     return (
       <SpotsListMessage tone="error">
@@ -145,11 +173,10 @@ export function SpotsList() {
     );
   }
 
-  if (state.spots.length === 0) {
-    return (
-      <SpotsListMessage>行きたい場所をまだ保存していません。</SpotsListMessage>
-    );
-  }
-
-  return <SpotsListContent spots={state.spots} />;
+  return (
+    <SpotsListContent
+      spots={state.spots}
+      onSpotCreated={handleSpotCreated}
+    />
+  );
 }

--- a/frontend/src/app/components/SpotsList.tsx
+++ b/frontend/src/app/components/SpotsList.tsx
@@ -2,13 +2,14 @@
 
 import { useEffect, useState } from "react";
 
+import type { Category } from "@/types/category";
 import type { Spot } from "@/types/spot";
 
 import { SpotCreateForm } from "./SpotCreateForm";
 
 type FetchState =
   | { status: "loading" }
-  | { status: "success"; spots: Spot[] }
+  | { status: "success"; categories: Category[]; spots: Spot[] }
   | { status: "error"; message: string };
 
 type SpotsListMessageProps = {
@@ -17,10 +18,12 @@ type SpotsListMessageProps = {
 };
 
 type SpotListItemProps = {
+  categories: Category[];
   spot: Spot;
 };
 
 type SpotsListContentProps = {
+  categories: Category[];
   spots: Spot[];
   onSpotCreated: (spot: Spot) => void;
 };
@@ -32,6 +35,10 @@ function formatSpotStatus(status: Spot["status"]) {
     case "visited":
       return "訪問済み";
   }
+}
+
+function findCategoryName(categories: Category[], categoryId: number) {
+  return categories.find((category) => category.id === categoryId)?.name;
 }
 
 function SpotsListMessage({ tone = "default", children }: SpotsListMessageProps) {
@@ -57,7 +64,9 @@ function SpotsListMessage({ tone = "default", children }: SpotsListMessageProps)
   );
 }
 
-function SpotListItem({ spot }: SpotListItemProps) {
+function SpotListItem({ categories, spot }: SpotListItemProps) {
+  const categoryName = findCategoryName(categories, spot.category_id);
+
   return (
     <li className="rounded-lg border border-zinc-200 bg-white p-4 shadow-sm">
       <div className="space-y-2">
@@ -68,17 +77,37 @@ function SpotListItem({ spot }: SpotListItemProps) {
           </span>
         </div>
 
-        <p className="text-sm text-zinc-500">Category ID: {spot.category_id}</p>
-        <p className="text-sm text-zinc-500">Name: {spot.name}</p>
+        <p className="text-sm text-zinc-500">
+          カテゴリー: {categoryName ?? `ID ${spot.category_id}`}
+        </p>
+
+        {spot.note && (
+          <p className="text-sm text-zinc-600">メモ: {spot.note}</p>
+        )}
+
+        {spot.url && (
+          <a
+            href={spot.url}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-block text-sm font-medium text-zinc-700 underline underline-offset-2"
+          >
+            URLを見る
+          </a>
+        )}
       </div>
     </li>
   );
 }
 
-function SpotsListContent({ spots, onSpotCreated }: SpotsListContentProps) {
+function SpotsListContent({
+  categories,
+  spots,
+  onSpotCreated,
+}: SpotsListContentProps) {
   return (
     <section className="space-y-6">
-      <SpotCreateForm onCreated={onSpotCreated} />
+      <SpotCreateForm categories={categories} onCreated={onSpotCreated} />
 
       <div className="space-y-1">
         <h2 className="text-xl font-semibold text-zinc-900">保存したスポット</h2>
@@ -92,7 +121,7 @@ function SpotsListContent({ spots, onSpotCreated }: SpotsListContentProps) {
       ) : (
         <ul className="space-y-3">
           {spots.map((spot) => (
-            <SpotListItem key={spot.id} spot={spot} />
+            <SpotListItem key={spot.id} categories={categories} spot={spot} />
           ))}
         </ul>
       )}
@@ -111,16 +140,24 @@ export function SpotsList() {
 
     const fetchSpots = async () => {
       try {
-        const response = await fetch(`${apiBaseUrl}/api/spots`);
+        const [spotsResponse, categoriesResponse] = await Promise.all([
+          fetch(`${apiBaseUrl}/api/spots`),
+          fetch(`${apiBaseUrl}/api/categories`),
+        ]);
 
-        if (!response.ok) {
-          throw new Error(`HTTP ${response.status}`);
+        if (!spotsResponse.ok) {
+          throw new Error(`Spots HTTP ${spotsResponse.status}`);
         }
 
-        const spots: Spot[] = await response.json();
+        if (!categoriesResponse.ok) {
+          throw new Error(`Categories HTTP ${categoriesResponse.status}`);
+        }
+
+        const spots: Spot[] = await spotsResponse.json();
+        const categories: Category[] = await categoriesResponse.json();
 
         if (!ignore) {
-          setState({ status: "success", spots });
+          setState({ status: "success", categories, spots });
         }
       } catch (error) {
         if (!ignore) {
@@ -148,6 +185,7 @@ export function SpotsList() {
 
       return {
         status: "success",
+        categories: currentState.categories,
         spots: [spot, ...currentState.spots],
       };
     });
@@ -175,6 +213,7 @@ export function SpotsList() {
 
   return (
     <SpotsListContent
+      categories={state.categories}
       spots={state.spots}
       onSpotCreated={handleSpotCreated}
     />

--- a/frontend/src/app/components/SpotsList.tsx
+++ b/frontend/src/app/components/SpotsList.tsx
@@ -41,6 +41,19 @@ function findCategoryName(categories: Category[], categoryId: number) {
   return categories.find((category) => category.id === categoryId)?.name;
 }
 
+function safeHttpUrl(url: string | null) {
+  if (!url) return null;
+
+  try {
+    const parsedUrl = new URL(url);
+    return parsedUrl.protocol === "http:" || parsedUrl.protocol === "https:"
+      ? parsedUrl.toString()
+      : null;
+  } catch {
+    return null;
+  }
+}
+
 async function fetchCategories(apiBaseUrl: string) {
   try {
     const response = await fetch(`${apiBaseUrl}/api/categories`);
@@ -81,6 +94,7 @@ function SpotsListMessage({ tone = "default", children }: SpotsListMessageProps)
 
 function SpotListItem({ categories, spot }: SpotListItemProps) {
   const categoryName = findCategoryName(categories, spot.category_id);
+  const safeUrl = safeHttpUrl(spot.url);
 
   return (
     <li className="rounded-lg border border-zinc-200 bg-white p-4 shadow-sm">
@@ -100,9 +114,9 @@ function SpotListItem({ categories, spot }: SpotListItemProps) {
           <p className="text-sm text-zinc-600">メモ: {spot.note}</p>
         )}
 
-        {spot.url && (
+        {safeUrl && (
           <a
-            href={spot.url}
+            href={safeUrl}
             target="_blank"
             rel="noreferrer"
             className="inline-block text-sm font-medium text-zinc-700 underline underline-offset-2"

--- a/frontend/src/types/category.ts
+++ b/frontend/src/types/category.ts
@@ -1,0 +1,6 @@
+export type Category = {
+  id: number;
+  name: string;
+  created_at: string;
+  updated_at: string;
+};

--- a/frontend/src/types/spot.ts
+++ b/frontend/src/types/spot.ts
@@ -1,3 +1,5 @@
+export type SpotStatus = "want_to_go" | "visited";
+
 export type Spot = {
   id: number;
   category_id: number;
@@ -5,8 +7,16 @@ export type Spot = {
   name: string;
   note: string | null;
   url: string | null;
-  status: "want_to_go" | "visited";
+  status: SpotStatus;
   visited_on: string | null;
   created_at: string;
   updated_at: string;
+};
+
+export type SpotFormValues = {
+  category_id: string;
+  name: string;
+  note: string;
+  url: string;
+  status: SpotStatus;
 };


### PR DESCRIPTION

## 概要

Spot作成フォームを追加し、Next.js フロントエンドから Rails API の `POST /api/spots` に連携できるようにしました。

あわせて、フォームのカテゴリー入力を ID 直入力ではなく既存カテゴリー名から選択する形にし、保存済みスポット一覧でもカテゴリー名・メモ・URLを表示するようにしました。


## やったこと

- Spot作成フォームを追加
- フォームから `POST /api/spots` を実行
- 作成成功時に一覧へ新しいSpotを追加
- 作成失敗時にエラーメッセージを表示
- Spot用のフォーム入力型を追加
- Category型を追加
- `GET /api/categories` でカテゴリー一覧を取得
- カテゴリーIDではなくカテゴリー名で選択できるように変更
- 一覧表示でカテゴリー名を表示
- メモがある場合のみ表示
- URLがある場合のみ表示し、別タブで開けるように変更

## 確認したこと

- [x] `docker compose exec frontend npm run lint`
- [x] `docker compose exec frontend npm run build`
- [x] `docker compose exec backend bundle exec rails test`
- [x] ブラウザでSpot一覧が表示されること
- [x] フォームからSpotを作成できること
- [x] 作成後、画面上の一覧に追加されること
- [x] カテゴリー名が表示されること
- [x] URLリンクが別タブで開くこと

## 補足

今回のIssueでは、まずフォームからAPIにPOSTして一覧へ反映するところまでを対象にしています。

実務視点では、今後以下のような改善余地があります。

- API呼び出し処理を `api helper` に切り出す
- フォームバリデーションを整理する
- 作成フォームをさらに小さなコンポーネントに分割する
- 成功メッセージや送信中のUIを改善する
- フロントエンドのコンポーネントテストを追加する
- `X-User-Id` の扱いを認証実装時に見直す

## 影響範囲

- frontend: Spot作成フォーム、Spot一覧表示
- backend: 変更なし
- DB: 変更なし

## 関連Issue
- Closes #60
