### PR TITLE
docs: add frontend and api guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,83 +87,41 @@ Do not introduce additional statuses unless explicitly needed.
 
 ---
 
-## 5. API Design Principles
-Use RESTful Rails routes.
+## 5. Guideline Loading Rules
+Always follow this `AGENTS.md`.
 
-Preferred route style:
-- GET /api/spots
-- GET /api/spots/:id
-- POST /api/spots
-- PATCH /api/spots/:id
-- DELETE /api/spots/:id
+Before implementing Rails API/backend changes, also read:
+- `docs/guidelines/api.md`
 
-Filtering should prefer query params when possible, for example:
-- GET /api/spots?category_id=1
+Before implementing Next.js/frontend changes, also read:
+- `docs/guidelines/frontend.md`
 
-General API rules:
-- use `namespace :api`
-- use `resources`
-- use strong parameters
-- return meaningful HTTP status codes
-- keep controllers thin
-- avoid custom non-RESTful routes unless clearly justified
+If a task touches both backend and frontend, read both guidelines.
+Do not load unrelated guideline files unless the task requires them.
 
 ---
 
-## 6. Validation and DB Rules
-Always think at both levels:
-- application-level validation
-- database-level constraints
+## 6. Backend Summary
+Rails API is responsible for data integrity and application rules.
 
-### Required validations
-Category:
-- name: presence
-
-Spot:
-- name: presence
-- status: presence
-- category: presence
-
-### Preferred DB constraints
-Use constraints in migrations where appropriate:
-- `null: false` for required fields
-- `default:` for natural defaults
-- foreign keys for associations
-
-Example principles:
-- `status` should default to `want_to_go`
-- `category_id` should be required
-- avoid relying only on model validation
+Use RESTful routes, strong parameters, meaningful HTTP status codes, model validations, and database constraints.
+For detailed API implementation rules, follow `docs/guidelines/api.md`.
 
 ---
 
-## 7. Controller Rules
-Controllers should stay thin.
+## 7. Frontend Summary
+Next.js is responsible for screens, routing, user experience, and Rails API calls.
 
-Controllers should mainly:
-- receive request params
-- call model/query logic
-- render JSON
-- return correct status codes
+Keep UI changes focused, handle loading / error / empty / success states, and avoid unnecessary Client Components.
+For detailed frontend implementation rules, follow `docs/guidelines/frontend.md`.
 
-Avoid putting large business logic directly in controllers.
-
-Use strong params in private methods, for example:
-
-```rb
-def spot_params
-  params.require(:spot).permit(:category_id, :name, :note, :url, :status, :visited_on)
-end
-```
-Do not use `permit!`.
-
-## Working rules
+## 8. Working Rules
 - Use Plan first for non-trivial tasks.
 - Keep changes minimal and focused.
 - One task = one focused PR.
 - Do not change unrelated files.
 
-## Git rules
+## 9. Git Rules
 - Branch naming:
   - feature/<issue-number>-short-description
   - fix/<issue-number>-short-description
@@ -177,11 +135,13 @@ Do not use `permit!`.
   - test: ...
   - chore: ...
 
-## Validation
+## 10. Validation
 - Backend: run test/lint before finishing
-- Frontend: run lint/typecheck before finishing if frontend exists
+- Frontend: run lint/build before finishing if frontend exists
+- If a validation command cannot be run, explain why in the summary.
 - Summarize changed files and why
 
-## Safety
+## 11. Safety
 - Do not edit secrets or production config unless explicitly asked.
-- Ask before changing schema, CI, or deployment files.
+- Do not change schema, CI, deployment, Docker, or environment files unless the task explicitly requires it.
+- If such changes are necessary, explain the reason and impact in the summary.

--- a/docs/guidelines/README.md
+++ b/docs/guidelines/README.md
@@ -1,0 +1,47 @@
+# Development Guidelines
+
+このディレクトリは、SpotLog の実装前に確認する開発ガイドラインを置く場所。
+Issue / PR の粒度、設計判断、レビュー観点をそろえ、変更を小さく安全に進めるために使う。
+
+## Purpose
+
+- frontend と backend の責務分離を明確にする。
+- 実装前に確認すべき判断基準を短くまとめる。
+- PR レビューで確認する観点をそろえる。
+- MVP の範囲を保ちながら、将来の本格開発へ移行しやすい構成にする。
+
+## Scope
+
+このディレクトリには、実装時に繰り返し参照する基準だけを書く。
+特定の Issue だけで必要になる詳細調査、長いコード例、技術選定メモは Issue 本文や PR 説明に残す。
+
+## Included Topics
+
+- Next.js と Rails API の責務分離
+- Server Component / Client Component の境界
+- API 呼び出し、型、error handling、cache の基本判断
+- REST route、HTTP status、validation、DB constraint の基本判断
+- 認証・認可・secret の安全境界
+- Issue 分割、テスト、PR 確認に使う checklist
+
+## Excluded Topics
+
+- 詳細なコード例の全文
+- 認証方式ごとの長い実装手順
+- SWR / TanStack Query / Server Actions / Route Handler の詳細比較
+- serializer / service / policy などの全パターン解説
+- 監視、cache、外部 API、file upload の本格運用手順
+
+## Documentation Rules
+
+- 実装前の判断ミスを防ぐ内容は guideline に書く。
+- 特定 Issue で初めて必要になる詳細は、Issue の調査メモや PR 説明に書く。
+- 現在の SpotLog にない大きな設計変更は、専用 Issue を切ってから扱う。
+- MVP の小ささを守るため、重要でも今すぐ不要な仕組みは「必要になったら検討」として残す。
+- ガイドラインは、読み切れる長さを保つ。
+
+## Maintenance
+
+- 新しい実装で繰り返し同じ判断が発生したら、該当 guideline を更新する。
+- 一度だけの判断や一時的なメモは、このディレクトリに追加しない。
+- 既存ルールと矛盾する方針を追加する場合は、理由を PR に明記する。

--- a/docs/guidelines/api.md
+++ b/docs/guidelines/api.md
@@ -1,0 +1,110 @@
+# API Implementation Guidelines
+
+SpotLog の API 実装では、Rails API の基本を学べる素直な REST 設計を優先する。
+controller を薄く保ち、validation と database constraint の両方でデータを守る。
+
+## Purpose
+
+このガイドラインは、API 実装前に確認する判断基準として使う。
+Rails API を単なる JSON 返却層にせず、アプリケーションの正しさと安全性を守る中核として設計するための最低限をまとめる。
+
+## 基本方針
+
+- MVP に必要な API だけを追加する。
+- API は resource 中心で設計する。
+- RESTful な route と HTTP method を使う。
+- `namespace :api` と `resources` を基本にする。
+- 新規 API 設計では `/api/v1` のように version を切る。SpotLog 既存 API は `/api` のため、移行は専用 Issue で扱う。
+- 1 Issue では、endpoint・model・validation などの主目的をひとつに絞る。
+- API 仕様、エラー形式、確認方法は PR に残す。
+- 変更後は `docker compose exec backend bin/rubocop` と `docker compose exec backend bin/rails test` を確認する。
+
+## Routes
+
+- 標準的な CRUD は `resources` を使う。
+- custom route は、REST では表現しにくい明確な理由がある場合だけ追加する。
+- 一覧の絞り込みは query params を優先する。
+- 例: `GET /api/spots?category_id=1`
+- URL には実装都合ではなく、API 利用者から見た resource を表す名前を使う。
+- URL に `create_spot` や `delete_spot` のような動詞を入れすぎない。
+- nest は 1-2 階層を目安にし、深くしすぎない。
+
+## Controllers
+
+- controller は request params を受け取り、model / scope / query object を呼び、JSON を返す場所にする。
+- 大きな business logic を controller に直接書かない。
+- strong parameters を使い、`permit!` は使わない。
+- render する JSON の形と HTTP status code を明確にする。
+- create は成功時 `201 Created`、validation error は `422 Unprocessable Entity` を基本にする。
+- destroy は成功時 `204 No Content` を基本にする。
+- 共通の例外処理は、必要になったら `ApplicationController` に集約する。
+
+## Models, Queries, and Services
+
+- association は model に定義する。
+- validation は model に書く。
+- まずは model method や scope で表現し、一覧取得や絞り込みが複雑になったら query object への分離を検討する。
+- scope や query object は、controller を読みやすくする目的で使う。
+- 複数 model をまたぐ処理、外部 API 連携、transaction を含む処理は service への分離を検討する。
+- 単純な CRUD では service を増やしすぎない。
+- premature abstraction は避ける。
+
+## Validation and Database Constraints
+
+- 必須項目は model validation と DB constraint の両方で守る。
+- `null: false`、`default:`、foreign key を適切に使う。
+- `status` のような固定値は、model 側で許可値を検証する。
+- default value は、domain 上自然なものだけにする。
+- migration では既存 data への影響を確認する。
+- schema 変更が必要な場合は、Issue の対象範囲と影響範囲に明記する。
+- migration は意味単位で小さく、可能な限り reversible にする。
+- index は主要導線から最小限で始める。遅さが見えたら SQL と `EXPLAIN` を根拠に追加する。
+
+## JSON Responses
+
+- API response は frontend が使いやすい形を優先する。
+- 不要な内部情報を返さない。
+- error response は、frontend が表示や分岐に使いやすい形にする。
+- validation error は、可能な範囲で `{ message: "...", errors: { field: ["..."] } }` の形に揃える。
+- 401 / 403 / 404 / 422 / 500 の意味を混ぜない。
+- 認証エラー、認可エラー、validation error、想定外エラーの形式をできるだけ揃える。
+- 一覧 API は、必要になった段階で pagination metadata を検討する。
+- 小さい API では明示的な `render json:` でよい。
+- response 形状が複数箇所で重複したり複雑になったら、serializer 的な object への分離を検討する。
+- 1 回だけの単純な response のために serializer gem や重い抽象化を追加しない。
+
+## Authentication and Authorization
+
+- frontend から送られた `user_id` や権限に関わる値を信用しない。
+- 認証と認可は分けて考える。
+- 所有者確認・権限確認の最終判断は Rails API 側で行う。
+- Pundit などの認可 gem は、認可ルールが増えてから検討する。
+- 認証方式を入れる Issue では、Cookie / CSRF / CORS / Token の方針を先に決める。
+
+## Security and Operations
+
+- secret、token、password、Cookie、CSRF token を response や log に出さない。
+- 外部 API 呼び出しは controller に直書きしない。
+- 例外を握りつぶさず、想定外エラーは調査できる形にする。
+- request id を追えると障害調査しやすい。
+- 高度な監視基盤は MVP 初期では不要だが、ログに残してよい情報と出してはいけない情報は最初から区別する。
+
+## Tests
+
+- model validation と association は model test で確認する。
+- endpoint の status code、response body、DB への反映は integration test で確認する。
+- query params を追加したら、絞り込み条件の test を追加する。
+- validation error と not found のような失敗系も確認する。
+- 認証・認可を追加したら、401 / 403 相当の test を追加する。
+- DB constraint を変える場合は、migration 後の test 実行まで確認する。
+
+## Implementation Checklist
+
+- この Issue の主目的はひとつに絞れているか。
+- resource と HTTP method は自然か。
+- response と error の形は既存 API と揃っているか。
+- strong parameters は必要な項目だけを許可しているか。
+- validation と DB constraint の両方で守るべき項目はないか。
+- frontend から来た user id や権限値を信用していないか。
+- migration / index は必要最小限か。
+- 成功系と失敗系の test があるか。

--- a/docs/guidelines/frontend.md
+++ b/docs/guidelines/frontend.md
@@ -1,0 +1,114 @@
+# Frontend Implementation Guidelines
+
+SpotLog の frontend 実装では、学習しやすさとレビューしやすさを優先する。
+大きな抽象化よりも、画面・状態・API 呼び出しの責務が読み取りやすい構成を選ぶ。
+
+## Purpose
+
+このガイドラインは、frontend 実装前に確認する判断基準として使う。
+詳細な設計パターンをすべて覚えるためではなく、Next.js + Rails API 構成で責務を間違えないための最低限をまとめる。
+
+## 基本方針
+
+- 1 Issue では、見た目・データ取得・フォーム・テストなどの主目的をひとつに絞る。
+- 既存の Next.js / React / Tailwind CSS の書き方に合わせる。
+- Next.js は画面、ルーティング、ユーザー体験、Rails API 呼び出しに集中する。
+- DB 更新、業務ロジック、認証・認可の最終判断は Rails API に置く。
+- MVP に不要な機能やデモ用の飾りは追加しない。
+- 画面から使われていないコード、仮の UI、不要な console 出力を残さない。
+- 変更後は原則として `docker compose exec frontend npm run lint` を確認する。
+- page 構成、routing、環境変数、Server Component / Client Component 境界を変更した場合は `docker compose exec frontend npm run build` も確認する。
+
+## Server and Client Components
+
+- App Router では、まず Server Component で作れるか考える。
+- `"use client"` は、フォーム、クリック操作、ブラウザ API、localStorage、リアルタイム更新などが必要な小さい部品に閉じ込める。
+- 表示だけの page / layout / list は、可能なら Server Component のままにする。
+- Server Component から Client Component に渡す props は、シリアライズ可能な値にする。
+- server-only な環境変数や API helper を Client Component から import しない。
+- 既存画面が Client Component で作られている場合、Issue の目的外なら大きな Server Component 化はしない。
+
+## Data Fetching
+
+- 初期表示データは、可能なら Server Component から Rails API を呼んで取得する。
+- 初期表示のためだけに `useEffect` を使わない。`useEffect` はブラウザ側の副作用や、既存の Client Component 内で必要な場合に限定する。
+- SWR / TanStack Query は、再検証、ポーリング、楽観的更新、複雑な cache invalidation が必要になってから検討する。
+- Server Actions は、DB を直接触る場所ではなく、Rails API を呼ぶ薄い層として使う。
+- Route Handler は Rails API の代替にしない。Cookie 変換や薄い BFF が必要な場合だけ検討する。
+- ユーザー依存データを扱う場合は、Next.js 側で意図せず cache しないよう方針を明示する。
+
+## Component Design
+
+- ページ全体の構成を持つ component と、表示部品の component を分ける。
+- component 名は役割が分かる名前にする。
+- 1 つの component が大きくなったら、次の責務を分離できないか確認する。
+  - データ取得
+  - フォーム入力
+  - フィルタや並び替えの状態
+  - 一覧 item / card 表示
+  - loading / error / empty 表示
+- props は必要な値だけを渡す。
+- 汎用化は、同じ構造が複数箇所で必要になってから検討する。
+- feature 固有の component / api / type は feature 配下に寄せ、複数 feature で使う型だけ `src/types` に置く。
+
+Recommended feature structure:
+
+```text
+src/features/spots/
+  components/
+  api/
+  types.ts
+  mapper.ts
+```
+
+## State Management
+
+- まずは React の `useState` / `useEffect` で扱う。
+- global state library は、複数画面で共有する明確な必要が出るまで追加しない。
+- loading / error / empty / success の UI 状態を意識して実装する。
+- API 通信中の二重送信を防ぐため、送信中 state を持つ。
+- form の初期値、送信値、リセット条件を component 内で読みやすく保つ。
+
+## API Calls
+
+- API base URL、JSON fetch、HTTP error handling は helper に寄せる。
+- API helper は最初から大きな client にしない。
+- Server Component / Server Action から使う API helper と、Client Component から使う API helper は分ける。
+- MVP では既存の API 呼び出し経路を優先し、すべての Rails API endpoint を proxy するためだけに Route Handler を追加しない。
+- Route Handler は Cookie handling、CORS simplification、internal API URL の隠蔽など、明確な理由がある場合だけ使う。
+- component 側では、できるだけ「何を取得・送信するか」が分かる形にする。
+- error message はユーザーに表示するものと、開発者が調査するものを混ぜすぎない。
+- `fetch` の `ok` 判定を忘れない。
+- API response の型と実際の JSON がずれる可能性を意識し、重要な API では mapper や runtime validation を検討する。
+
+## UI and Accessibility
+
+- 入力欄には `label` を付ける。
+- button の disabled state、送信中表示、error 表示を用意する。
+- レスポンシブ表示で text や button が崩れないか確認する。
+- 色や余白は既存 UI のトーンに合わせる。
+- 画面内テキストは、機能説明よりもユーザーが次に取る行動を分かりやすくする。
+
+## Security Boundary
+
+- ブラウザに secret、private API key、server-only な環境変数を出さない。
+- frontend の表示制御は UX のためであり、認可の最終判断ではない。
+- 編集ボタンを隠しても API は直接叩けるため、所有者確認や権限確認は Rails API 側で必ず行う。
+- 学習用の暫定 user id や header は永続的な認証方式として扱わない。
+- 認証が必要になったら、Cookie / CSRF / CORS / Token の方針を専用 Issue で決める。
+
+## Tests
+
+- UI を変更したら、壊れやすい状態から優先してテストする。
+- 優先度は loading / error / empty / success / form submit の順で考える。
+- API 通信を含む component test では、fetch mock を使う。
+- テストがない段階では、lint / build とブラウザでの目視確認を最低限行う。
+
+## Implementation Checklist
+
+- この Issue の主目的はひとつに絞れているか。
+- 本当に Client Component が必要か。
+- 初期表示データを `useEffect` で取得していないか。
+- server-only な値をブラウザ側に出していないか。
+- loading / error / empty / success があるか。
+- API helper、型、component の置き場所は今後追いやすいか。


### PR DESCRIPTION
## 概要
frontend / API 実装時に参照する開発ガイドラインを追加し、AGENTS.md を常時読むプロジェクト前提として整理しました。

## 変更内容
- `docs/guidelines/frontend.md` を追加
- `docs/guidelines/api.md` を追加
- `docs/guidelines/README.md` を追加
- `AGENTS.md` に guideline の読み分けルールを追加し、API 詳細ルールを guideline 側へ整理

## 変更理由
Codex が毎回読む `AGENTS.md` を軽く保ちつつ、Rails API 実装時・Next.js frontend 実装時に必要な判断基準を追加で参照できるようにするためです。

## 動作確認
- [x] ローカルで期待どおり動くことを確認した
- [ ] 必要なテストを追加または更新した
- [x] 既存機能に影響がないことを確認した

確認した内容:
- Markdown / docs 変更のみであることを確認
- `git diff --check` で空白エラーがないことを確認
- stage 対象が `AGENTS.md` と `docs/guidelines/` のみであることを確認

## テスト
- 実行コマンド: `git diff --check`
- 結果: 成功

Backend / frontend のテスト・build は未実行です。docs と AGENTS.md のみの変更のためです。

## 影響範囲
- frontend: なし
- backend: なし
- db: なし
- infra: なし
- docs: frontend / API 実装ガイドラインを追加
- repository structure: `docs/guidelines/` を追加

## 関連Issue
- closes #67

## 補足
レビューでは、`AGENTS.md` が常時読む前提として十分軽いか、API / frontend の詳細ルールが各 guideline に適切に分離されているかを見てください。
